### PR TITLE
Refactor to npm workspaces, flow-driven web loader, and correct datapack ordering/provenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: ci
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: |
+          if [ -f package-lock.json ]; then
+            npm ci
+          else
+            npm install
+          fi
+      - run: npm test
+      - run: npm run typecheck
+      - run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+.pnpm-store
+dist
+coverage
+.DS_Store
+apps/web/.vite

--- a/README.md
+++ b/README.md
@@ -1,1 +1,71 @@
-# DndCharacterBuilder
+# D&D 3.5 Character Builder (Web, beginner-first)
+
+A beginner-friendly, open-source MVP character builder for **D&D 3.5 SRD content**.
+
+## What this is
+- A guided step-by-step web wizard for creating a level 1 character.
+- Deterministic, data-driven rules engine with provenance for every derived number.
+- Pack-based architecture so future expansions can be enabled/disabled as data packs.
+
+## Legal note
+- This repository is intended to include **only SRD/OGL-compatible content**.
+- It does **not** include copyrighted full rulebook text.
+- It does **not** scrape PDFs from the internet.
+- User-uploaded private PDFs are out of scope and are not stored or redistributed.
+
+## Why data-driven
+Rules are encoded as pack entities + DSL effects/constraints, not hardcoded in the UI. The UI is a thin client that calls engine APIs.
+
+## Monorepo layout
+- `apps/web` React/Vite wizard UI.
+- `packages/engine` pure deterministic rules engine.
+- `packages/datapack` pack loader, dependency sort, merge/patch, fingerprint.
+- `packages/schema` zod schemas for contracts and pack definitions.
+- `packages/contracts` pack contract test runner.
+- `packs/srd-35e-minimal` minimal SRD demo pack.
+- `docs/` architecture/spec/testing docs.
+
+## Run locally
+```bash
+npm install
+npm run dev
+```
+
+### Test and quality
+```bash
+npm test
+npm run typecheck
+npm run lint
+npm run build
+```
+
+## Pack system and how to add a pack
+1. Add `packs/<pack-id>/manifest.json` with id/version/priority/dependencies.
+2. Add entities (`races/classes/feats/items/skills/rules`).
+3. Add `flows/character-creation.flow.json`.
+4. Optional patches in `patches/*.json`.
+5. Add `contracts/*.json` fixture for expected behavior.
+
+## MVP Checklist
+[ ] Monorepo scaffold (apps/web, packages/engine, packages/datapack, packages/schema, packages/contracts)
+[ ] Data pack loader + dependency resolution
+[ ] JSON schema validation
+[ ] Engine core APIs implemented
+[ ] DSL interpreter implemented (effects + constraints)
+[ ] Provenance tracking implemented
+[ ] Minimal SRD 3.5 pack created (Human + Fighter 1 + items + feats + rules)
+[ ] Wizard UI end-to-end flow
+[ ] JSON export
+[ ] Unit tests + contract tests + CI
+
+## Next TODO
+- Add more SRD content (spells, more classes, more races)
+- Add printable PDF export
+- Add save/load multiple characters
+- Add pack authoring UI
+- Add localization (CN/EN)
+
+## Roadmap (short)
+- Expand data pack coverage while preserving deterministic behavior.
+- Improve beginner guidance and explanations.
+- Add full printable output and richer validation UX.

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>D&D 3.5 Character Builder</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@dcb/web",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite --host 0.0.0.0 --port 4173",
+    "build": "tsc -p tsconfig.json --noEmit && vite build",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@dcb/datapack": "file:../../packages/datapack",
+    "@dcb/engine": "file:../../packages/engine",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "@dcb/schema": "file:../../packages/schema"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.3.4",
+    "typescript": "^5.7.2",
+    "vite": "^5.4.11",
+    "vitest": "^2.1.8",
+    "@testing-library/react": "^16.1.0",
+    "@testing-library/user-event": "^14.5.2",
+    "jsdom": "^25.0.1"
+  }
+}

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { App } from './App';
+
+describe('wizard e2e-ish happy path', () => {
+  it('lets user complete flow and see final stats', async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.type(screen.getByPlaceholderText('Enter character name'), 'Aric');
+    await user.click(screen.getByText('Next'));
+    await user.clear(screen.getByDisplayValue('10'));
+    const strInput = screen.getAllByRole('spinbutton')[0];
+    await user.clear(strInput);
+    await user.type(strInput, '16');
+    await user.click(screen.getByText('Next'));
+    await user.click(screen.getByLabelText('Human'));
+    await user.click(screen.getByText('Next'));
+    await user.click(screen.getByLabelText('Fighter (Level 1)'));
+    await user.click(screen.getByText('Next'));
+    await user.click(screen.getByLabelText('Power Attack'));
+    await user.click(screen.getByText('Next'));
+    await user.click(screen.getByLabelText('Chainmail'));
+    await user.click(screen.getByLabelText('Heavy Wooden Shield'));
+    await user.click(screen.getByText('Next'));
+
+    expect(screen.getByText('Review')).toBeTruthy();
+    expect(screen.getByText(/AC/).textContent).toContain('18');
+  });
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,0 +1,164 @@
+import { useMemo, useState } from 'react';
+import { resolveLoadedPacks } from '@dcb/datapack';
+import { loadMinimalPack } from './loadMinimalPack';
+import { applyChoice, finalizeCharacter, initialState, listChoices, type CharacterState } from '@dcb/engine';
+
+const minimalPack = loadMinimalPack();
+const resolvedData = resolveLoadedPacks([minimalPack], ['srd-35e-minimal']);
+const context = { enabledPackIds: ['srd-35e-minimal'], resolvedData };
+
+export function App() {
+  const [state, setState] = useState<CharacterState>(initialState);
+  const [stepIndex, setStepIndex] = useState(0);
+  const [showProv, setShowProv] = useState(false);
+
+  const flowSteps = context.resolvedData.flow.steps;
+  const reviewStep = { id: 'review', kind: 'review', label: 'Review', source: { type: 'manual' as const } };
+  const wizardSteps = [...flowSteps, reviewStep];
+  const currentStep = wizardSteps[stepIndex];
+
+  const choices = useMemo(() => listChoices(state, context), [state]);
+  const choiceMap = new Map(choices.map((c) => [c.stepId, c]));
+  const sheet = useMemo(() => finalizeCharacter(state, context), [state]);
+
+  const setAbility = (key: string, value: number) => {
+    setState((prev) => applyChoice(prev, 'abilities', { ...prev.abilities, [key]: value }));
+  };
+
+  const exportJson = () => {
+    const blob = new Blob([JSON.stringify(sheet, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${sheet.metadata.name || 'character'}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const renderCurrentStep = () => {
+    if (currentStep.id === 'review') {
+      return (
+        <section>
+          <h2>Review</h2>
+          <p><strong>{sheet.metadata.name}</strong></p>
+          <div className="grid two">
+            {Object.entries(sheet.stats).map(([k, v]) => <div key={k}><strong>{k}</strong>: {String(v)}</div>)}
+          </div>
+          <button onClick={exportJson}>Export JSON</button>
+          <button onClick={() => setShowProv((s) => !s)}>Toggle provenance</button>
+          {showProv && <pre>{JSON.stringify(sheet.provenance, null, 2)}</pre>}
+          <h3>Printable HTML Character Sheet</h3>
+          <article className="sheet">
+            <p>Name: {sheet.metadata.name}</p>
+            <p>Race: {String(state.selections.race ?? '-')} / Class: {String(state.selections.class ?? '-')}</p>
+            <p>AC: {String(sheet.stats.ac)} | HP: {String(sheet.stats.hp)} | BAB: {String(sheet.stats.bab)}</p>
+          </article>
+        </section>
+      );
+    }
+
+    if (currentStep.kind === 'metadata') {
+      return (
+        <section>
+          <h2>{currentStep.label}</h2>
+          <input
+            value={state.metadata.name ?? ''}
+            onChange={(e) => setState((s) => applyChoice(s, currentStep.id, e.target.value))}
+            placeholder="Enter character name"
+          />
+        </section>
+      );
+    }
+
+    if (currentStep.kind === 'abilities') {
+      return (
+        <section>
+          <h2>{currentStep.label} (Manual, 3-18)</h2>
+          <div className="grid">
+            {Object.entries(state.abilities).map(([key, value]) => (
+              <label key={key}>{key.toUpperCase()}
+                <input type="number" min={3} max={18} value={value} onChange={(e) => setAbility(key, Number(e.target.value))} />
+              </label>
+            ))}
+          </div>
+        </section>
+      );
+    }
+
+    if (currentStep.source.type === 'entityType') {
+      const stepChoice = choiceMap.get(currentStep.id);
+      const options = stepChoice?.options ?? [];
+      const limit = currentStep.source.limit ?? 1;
+
+      if (limit <= 1) {
+        const currentValue = currentStep.id === 'feat'
+          ? String(((state.selections.feats as string[] | undefined) ?? [])[0] ?? '')
+          : String(state.selections[currentStep.id] ?? '');
+
+        return (
+          <Picker
+            title={currentStep.label}
+            options={options}
+            value={currentValue}
+            onSelect={(id) => {
+              if (currentStep.id === 'feat') {
+                setState((s) => applyChoice(s, currentStep.id, [id]));
+                return;
+              }
+              setState((s) => applyChoice(s, currentStep.id, id));
+            }}
+          />
+        );
+      }
+
+      const selected = (state.selections[currentStep.id] as string[] | undefined) ?? [];
+      return (
+        <fieldset>
+          <legend>{currentStep.label}</legend>
+          {options.map((o) => (
+            <label key={o.id}>
+              <input
+                type="checkbox"
+                checked={selected.includes(o.id)}
+                onChange={(e) => {
+                  const next = e.target.checked ? [...selected, o.id] : selected.filter((item) => item !== o.id);
+                  setState((s) => applyChoice(s, currentStep.id, next));
+                }}
+              />
+              {o.label}
+            </label>
+          ))}
+        </fieldset>
+      );
+    }
+
+    return null;
+  };
+
+  return (
+    <main className="container">
+      <h1>D&D 3.5 Beginner Character Builder (MVP)</h1>
+      <p className="subtitle">Data-driven SRD-only wizard with deterministic rules + provenance.</p>
+      <p>Step {stepIndex + 1} / {wizardSteps.length}</p>
+      {renderCurrentStep()}
+      <footer className="actions">
+        <button disabled={stepIndex === 0} onClick={() => setStepIndex((s) => s - 1)}>Back</button>
+        <button disabled={stepIndex === wizardSteps.length - 1} onClick={() => setStepIndex((s) => s + 1)}>Next</button>
+      </footer>
+    </main>
+  );
+}
+
+function Picker({ title, options, value, onSelect }: { title: string; options: Array<{ id: string; label: string }>; value: string; onSelect: (id: string) => void; }) {
+  return (
+    <section>
+      <h2>{title}</h2>
+      {options.map((o) => (
+        <label key={o.id}>
+          <input type="radio" name={title} checked={value === o.id} onChange={() => onSelect(o.id)} />
+          {o.label}
+        </label>
+      ))}
+    </section>
+  );
+}

--- a/apps/web/src/loadMinimalPack.ts
+++ b/apps/web/src/loadMinimalPack.ts
@@ -1,0 +1,28 @@
+import type { Entity, Flow, Manifest } from '@dcb/schema';
+import type { LoadedPack } from '@dcb/datapack';
+
+import manifestJson from '../../../packs/srd-35e-minimal/manifest.json';
+import racesJson from '../../../packs/srd-35e-minimal/entities/races.json';
+import classesJson from '../../../packs/srd-35e-minimal/entities/classes.json';
+import featsJson from '../../../packs/srd-35e-minimal/entities/feats.json';
+import itemsJson from '../../../packs/srd-35e-minimal/entities/items.json';
+import skillsJson from '../../../packs/srd-35e-minimal/entities/skills.json';
+import rulesJson from '../../../packs/srd-35e-minimal/entities/rules.json';
+import flowJson from '../../../packs/srd-35e-minimal/flows/character-creation.flow.json';
+
+export function loadMinimalPack(): LoadedPack {
+  return {
+    manifest: manifestJson as Manifest,
+    entities: {
+      races: racesJson as Entity[],
+      classes: classesJson as Entity[],
+      feats: featsJson as Entity[],
+      items: itemsJson as Entity[],
+      skills: skillsJson as Entity[],
+      rules: rulesJson as Entity[]
+    },
+    flow: flowJson as Flow,
+    patches: [],
+    packPath: 'packs/srd-35e-minimal'
+  };
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { App } from './App';
+import './styles.css';
+
+createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1,0 +1,9 @@
+body { font-family: Arial, sans-serif; background: #f7f7fa; margin: 0; }
+.container { max-width: 920px; margin: 0 auto; background: white; padding: 1rem 1.5rem; min-height: 100vh; }
+.subtitle { color: #555; }
+.grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.75rem; }
+.grid.two { grid-template-columns: repeat(2, 1fr); }
+.actions { margin-top: 1rem; display: flex; gap: 0.5rem; }
+label { display: block; margin-bottom: 0.5rem; }
+.sheet { border: 1px solid #ccc; padding: 0.75rem; background: #fffdf4; }
+button { margin-right: 0.5rem; }

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "vite.config.ts"]
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,0 +1,12 @@
+import path from 'node:path';
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    fs: {
+      allow: [path.resolve(__dirname, '../..')]
+    }
+  }
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom'
+  }
+});

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,42 @@
+# Architecture
+
+## Module/Data Flow
+
+```text
+[packs/* JSON] -> [packages/datapack]
+                  - validate manifest/entities/flow
+                  - dependency topo sort + priority
+                  - merge + patch + fingerprint
+                          |
+                          v
+                   resolved pack set
+                          |
+                          v
+                    [packages/engine]
+         listChoices/applyChoice/validate/finalize
+         - deterministic DSL interpreter
+         - prerequisites + exclusivity
+         - derived stats + provenance
+                          |
+                          v
+                     [apps/web]
+             thin wizard UI + JSON export + HTML sheet
+```
+
+## Determinism
+- Engine APIs are pure and deterministic.
+- Character `state` stores only user selections, not derived stats.
+- Derived stats are recomputed on finalize from resolved pack data.
+
+## Provenance
+Each applied effect emits a provenance record:
+
+```json
+{
+  "targetPath": "stats.ac",
+  "delta": 2,
+  "source": { "packId": "srd-35e-minimal", "entityId": "heavy-wooden-shield" }
+}
+```
+
+This powers “why is this number this number?” in the review UI.

--- a/docs/datapack-spec.md
+++ b/docs/datapack-spec.md
@@ -1,0 +1,53 @@
+# Datapack Specification
+
+## Folder structure
+
+```text
+packs/<pack-id>/
+  manifest.json
+  entities/
+    races.json
+    classes.json
+    feats.json
+    items.json
+    skills.json
+    rules.json
+  flows/
+    character-creation.flow.json
+  patches/
+    *.json (optional)
+  contracts/
+    *.json
+```
+
+## `manifest.json`
+- `id` (string, stable)
+- `name` (string)
+- `version` (semver string)
+- `priority` (number; higher/lower order via resolver)
+- `dependencies` (pack id array)
+- `compatibleEngineRange` (optional)
+
+## Entity ID conventions
+- Use lowercase kebab-case IDs (`fighter-1`, `power-attack`).
+- IDs must be stable across versions for reliable overrides.
+
+## Merge/override rules
+1. Resolver topologically sorts enabled packs by dependency, then priority.
+2. Entities merge by `entityType + id`.
+3. Later precedence overrides previous values.
+4. Optional patches apply after entity merge.
+5. Resolver emits deterministic SHA-256 fingerprint from resolved pack set.
+
+## Example snippet
+
+```json
+{
+  "id": "chainmail",
+  "name": "Chainmail",
+  "entityType": "items",
+  "effects": [
+    { "kind": "add", "targetPath": "stats.ac", "value": { "const": 5 } }
+  ]
+}
+```

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -1,0 +1,24 @@
+# Testing Strategy
+
+## 1) Engine unit tests
+- Determinism test: same state/context => same final sheet.
+- Snapshot-like assertions for known selections.
+
+## 2) Datapack validation tests
+- Schema validation via zod.
+- Dependency cycle detection in resolver.
+- Basic integrity checks through resolver loading.
+
+## 3) Pack contract tests
+- Each pack ships fixtures under `packs/<id>/contracts/*.json`.
+- Fixture defines packs, actions, and expected subset checks.
+- Runner applies actions through engine APIs and asserts outcomes.
+
+## 4) Minimal E2E
+- Web wizard happy-path in `apps/web/src/App.test.tsx`.
+- Validates user can progress through steps and see final output.
+
+## Adding a new contract fixture
+1. Create `packs/<id>/contracts/<name>.json`.
+2. Specify `enabledPacks`, `initialState`, `actions`, `expected`.
+3. Run `npm test`.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "dnd-character-builder",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
+  "scripts": {
+    "dev": "npm --workspace @dcb/web run dev",
+    "build": "npm --workspaces run build",
+    "typecheck": "npm --workspaces run typecheck",
+    "lint": "npm --workspaces run lint",
+    "test": "npm --workspaces run test"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "typescript": "^5.7.2"
+  }
+}

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@dcb/contracts",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@dcb/datapack": "file:../datapack",
+    "@dcb/engine": "file:../engine",
+    "@dcb/schema": "file:../schema"
+  },
+  "devDependencies": {
+    "vitest": "^2.1.8"
+  }
+}

--- a/packages/contracts/src/contracts.test.ts
+++ b/packages/contracts/src/contracts.test.ts
@@ -1,0 +1,9 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { runContracts } from "./index";
+
+describe("pack contracts", () => {
+  it("runs all contract fixtures", () => {
+    expect(() => runContracts(path.resolve(process.cwd(), "../../packs"))).not.toThrow();
+  });
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,0 +1,46 @@
+import fs from "node:fs";
+import path from "node:path";
+import { ContractFixtureSchema } from "@dcb/schema";
+import { resolvePackSet } from "@dcb/datapack";
+import { applyChoice, finalizeCharacter, initialState, listChoices, validateState, type CharacterState } from "@dcb/engine";
+
+function containsSubset(target: Record<string, unknown>, subset: Record<string, unknown>): boolean {
+  return Object.entries(subset).every(([k, v]) => {
+    const tv = target[k];
+    if (typeof v === "object" && v !== null && typeof tv === "object" && tv !== null) return containsSubset(tv as Record<string, unknown>, v as Record<string, unknown>);
+    return tv === v;
+  });
+}
+
+export function runContracts(packsRoot: string): void {
+  const packDirs = fs.readdirSync(packsRoot).map((name) => path.join(packsRoot, name));
+  for (const packDir of packDirs) {
+    const contractsDir = path.join(packDir, "contracts");
+    if (!fs.existsSync(contractsDir)) continue;
+    for (const file of fs.readdirSync(contractsDir).filter((f) => f.endsWith(".json"))) {
+      const fixture = ContractFixtureSchema.parse(JSON.parse(fs.readFileSync(path.join(contractsDir, file), "utf8")));
+      const resolved = resolvePackSet(packsRoot, fixture.enabledPacks);
+      const context = { enabledPackIds: fixture.enabledPacks, resolvedData: resolved };
+      let state: CharacterState = { ...initialState, ...(fixture.initialState as Partial<CharacterState>) };
+      for (const action of fixture.actions) {
+        state = applyChoice(state, action.choiceId, action.selection);
+      }
+
+      const choices = listChoices(state, context).flatMap((c) => c.options.map((o) => o.id));
+      for (const expected of fixture.expected.availableChoicesContains ?? []) {
+        if (!choices.includes(expected)) throw new Error(`Expected choice ${expected} not found in ${file}`);
+      }
+
+      const errors = validateState(state, context);
+      const errorCodes = errors.map((e) => e.code);
+      for (const expectedCode of fixture.expected.validationErrorCodes ?? []) {
+        if (!errorCodes.includes(expectedCode)) throw new Error(`Expected validation code ${expectedCode} not found in ${file}`);
+      }
+
+      const final = finalizeCharacter(state, context) as unknown as Record<string, unknown>;
+      if (fixture.expected.finalSheetSubset && !containsSubset(final, fixture.expected.finalSheetSubset)) {
+        throw new Error(`Expected final sheet subset mismatch in ${file}`);
+      }
+    }
+  }
+}

--- a/packages/contracts/tsconfig.json
+++ b/packages/contracts/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/datapack/package.json
+++ b/packages/datapack/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@dcb/datapack",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@dcb/schema": "file:../schema"
+  },
+  "devDependencies": {
+    "vitest": "^2.1.8"
+  }
+}

--- a/packages/datapack/src/datapack.test.ts
+++ b/packages/datapack/src/datapack.test.ts
@@ -1,0 +1,55 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { LoadedPack } from "./index";
+import { resolveLoadedPacks, resolvePackSet, topoSortPacks } from "./index";
+
+function makePack(id: string, priority: number, dependencies: string[] = []): LoadedPack {
+  return {
+    manifest: { id, name: id, version: "1.0.0", priority, dependencies },
+    entities: {
+      races: [],
+      classes: [],
+      feats: [],
+      items: [],
+      skills: [],
+      rules: [{ id: `${id}-rule`, name: `${id}-rule`, entityType: "rules", effects: [] }]
+    },
+    flow: { steps: [{ id: "name", kind: "metadata", label: "Name", source: { type: "manual" } }] },
+    patches: [],
+    packPath: id
+  };
+}
+
+describe("resolvePackSet", () => {
+  it("loads minimal pack and computes fingerprint", () => {
+    const root = path.resolve(process.cwd(), "../../packs");
+    const resolved = resolvePackSet(root, ["srd-35e-minimal"]);
+    expect(resolved.entities.races?.human?.name).toBe("Human");
+    expect(resolved.entities.races?.human?._source.packId).toBe("srd-35e-minimal");
+    expect(resolved.fingerprint.length).toBe(64);
+  });
+
+  it("preserves dependency order even when priority conflicts", () => {
+    const base = makePack("base", 100);
+    const addon = makePack("addon", 1, ["base"]);
+    const independent = makePack("independent", 0);
+
+    const sorted = topoSortPacks([base, addon, independent], ["addon", "independent"]);
+    const ids = sorted.map((pack) => pack.manifest.id);
+
+    expect(ids.indexOf("base")).toBeLessThan(ids.indexOf("addon"));
+    expect(ids).toEqual(["independent", "base", "addon"]);
+  });
+
+  it("tracks source pack metadata for overriding patches", () => {
+    const base = makePack("base", 1);
+    base.entities.rules = [{ id: "shared", name: "Shared", entityType: "rules", effects: [] }];
+
+    const override = makePack("override", 2, ["base"]);
+    override.patches = [{ op: "mergeEntity", entityType: "rules", id: "shared", value: { name: "Overridden" } }];
+
+    const resolved = resolveLoadedPacks([base, override], ["override"]);
+    expect(resolved.entities.rules.shared.name).toBe("Overridden");
+    expect(resolved.entities.rules.shared._source.packId).toBe("override");
+  });
+});

--- a/packages/datapack/src/index.ts
+++ b/packages/datapack/src/index.ts
@@ -1,0 +1,204 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { FlowSchema, ManifestSchema, type Entity, type Flow, type Manifest } from "@dcb/schema";
+
+export interface LoadedPack {
+  manifest: Manifest;
+  entities: Record<string, Entity[]>;
+  flow: Flow;
+  patches: Array<{ op: "mergeEntity"; entityType: string; id: string; value: Partial<Entity> }>;
+  packPath: string;
+}
+
+export interface EntitySourceMetadata {
+  packId: string;
+  version: string;
+}
+
+export type ResolvedEntity = Entity & { _source: EntitySourceMetadata };
+
+export interface ResolvedPackSet {
+  orderedPackIds: string[];
+  manifests: Manifest[];
+  entities: Record<string, Record<string, ResolvedEntity>>;
+  flow: Flow;
+  fingerprint: string;
+}
+
+const ENTITY_FILES = ["races", "classes", "feats", "items", "skills", "rules"];
+
+export function loadPack(packPath: string): LoadedPack {
+  const manifest = ManifestSchema.parse(JSON.parse(fs.readFileSync(path.join(packPath, "manifest.json"), "utf8")));
+  const entities: Record<string, Entity[]> = {};
+
+  for (const entityFile of ENTITY_FILES) {
+    const filePath = path.join(packPath, "entities", `${entityFile}.json`);
+    const list = fs.existsSync(filePath) ? JSON.parse(fs.readFileSync(filePath, "utf8")) : [];
+    entities[entityFile] = list;
+  }
+
+  const flow = FlowSchema.parse(JSON.parse(fs.readFileSync(path.join(packPath, "flows", "character-creation.flow.json"), "utf8")));
+
+  const patchesDir = path.join(packPath, "patches");
+  const patchFiles = fs.existsSync(patchesDir) ? fs.readdirSync(patchesDir).filter((f) => f.endsWith(".json")) : [];
+  const patches = patchFiles.flatMap((file) => JSON.parse(fs.readFileSync(path.join(patchesDir, file), "utf8")));
+
+  return { manifest, entities, flow, patches, packPath };
+}
+
+function priorityComparator(a: LoadedPack, b: LoadedPack): number {
+  if (a.manifest.priority !== b.manifest.priority) return a.manifest.priority - b.manifest.priority;
+  return a.manifest.id.localeCompare(b.manifest.id);
+}
+
+function collectRequiredPackIds(byId: Map<string, LoadedPack>, enabledPackIds: string[]): Set<string> {
+  const required = new Set<string>();
+  const visiting = new Set<string>();
+
+  const visit = (id: string): void => {
+    if (required.has(id)) return;
+    if (visiting.has(id)) throw new Error(`Dependency cycle detected at ${id}`);
+    const pack = byId.get(id);
+    if (!pack) throw new Error(`Missing dependency pack ${id}`);
+    visiting.add(id);
+    for (const dep of pack.manifest.dependencies) {
+      visit(dep);
+    }
+    visiting.delete(id);
+    required.add(id);
+  };
+
+  for (const enabledId of enabledPackIds) visit(enabledId);
+  return required;
+}
+
+export function topoSortPacks(packs: LoadedPack[], enabledPackIds: string[]): LoadedPack[] {
+  const byId = new Map(packs.map((pack) => [pack.manifest.id, pack]));
+  const requiredPackIds = collectRequiredPackIds(byId, enabledPackIds);
+
+  const indegree = new Map<string, number>();
+  const dependents = new Map<string, string[]>();
+
+  for (const packId of requiredPackIds) {
+    const pack = byId.get(packId);
+    if (!pack) throw new Error(`Missing dependency pack ${packId}`);
+    indegree.set(packId, 0);
+    dependents.set(packId, []);
+  }
+
+  for (const packId of requiredPackIds) {
+    const pack = byId.get(packId);
+    if (!pack) throw new Error(`Missing dependency pack ${packId}`);
+    for (const dep of pack.manifest.dependencies) {
+      if (!requiredPackIds.has(dep)) continue;
+      indegree.set(packId, (indegree.get(packId) ?? 0) + 1);
+      dependents.get(dep)?.push(packId);
+    }
+  }
+
+  const queue = Array.from(requiredPackIds)
+    .filter((id) => (indegree.get(id) ?? 0) === 0)
+    .map((id) => byId.get(id)!)
+    .sort(priorityComparator);
+
+  const sorted: LoadedPack[] = [];
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    sorted.push(current);
+
+    for (const dependentId of dependents.get(current.manifest.id) ?? []) {
+      const nextIndegree = (indegree.get(dependentId) ?? 0) - 1;
+      indegree.set(dependentId, nextIndegree);
+      if (nextIndegree === 0) {
+        const dependent = byId.get(dependentId);
+        if (!dependent) throw new Error(`Missing dependency pack ${dependentId}`);
+        queue.push(dependent);
+        queue.sort(priorityComparator);
+      }
+    }
+  }
+
+  if (sorted.length !== requiredPackIds.size) {
+    const unresolved = Array.from(requiredPackIds).filter((id) => !sorted.some((pack) => pack.manifest.id === id));
+    throw new Error(`Dependency cycle detected among packs: ${unresolved.join(", ")}`);
+  }
+
+  return sorted;
+}
+
+function stableSerialize(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map((item) => stableSerialize(item)).join(",")}]`;
+
+  const entries = Object.entries(value as Record<string, unknown>)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, val]) => `${JSON.stringify(key)}:${stableSerialize(val)}`);
+
+  return `{${entries.join(",")}}`;
+}
+
+export function resolveLoadedPacks(loaded: LoadedPack[], enabledPackIds: string[]): ResolvedPackSet {
+  const sorted = topoSortPacks(loaded, enabledPackIds);
+
+  const entities: Record<string, Record<string, ResolvedEntity>> = {};
+  let flow: Flow | undefined;
+
+  for (const pack of sorted) {
+    for (const [entityType, list] of Object.entries(pack.entities)) {
+      entities[entityType] ??= {};
+      for (const entity of list) {
+        entities[entityType][entity.id] = {
+          ...entity,
+          entityType,
+          _source: { packId: pack.manifest.id, version: pack.manifest.version }
+        };
+      }
+    }
+    for (const patch of pack.patches) {
+      if (patch.op === "mergeEntity") {
+        const entityBucket = entities[patch.entityType];
+        const prev = entityBucket?.[patch.id];
+        if (entityBucket && prev) {
+          entityBucket[patch.id] = {
+            ...prev,
+            ...patch.value,
+            _source: { packId: pack.manifest.id, version: pack.manifest.version }
+          };
+        }
+      }
+    }
+    flow = pack.flow;
+  }
+
+  if (!flow) throw new Error("No flow found for enabled packs");
+
+  const fingerprint = crypto
+    .createHash("sha256")
+    .update(
+      stableSerialize({
+        packs: sorted.map((pack) => ({ id: pack.manifest.id, version: pack.manifest.version, priority: pack.manifest.priority })),
+        entities,
+        flow
+      })
+    )
+    .digest("hex");
+
+  return {
+    orderedPackIds: sorted.map((pack) => pack.manifest.id),
+    manifests: sorted.map((pack) => pack.manifest),
+    entities,
+    flow,
+    fingerprint
+  };
+}
+
+export function resolvePackSet(allPacksRoot: string, enabledPackIds: string[]): ResolvedPackSet {
+  const packDirs = fs
+    .readdirSync(allPacksRoot, { withFileTypes: true })
+    .filter((dirent) => dirent.isDirectory())
+    .map((dirent) => path.join(allPacksRoot, dirent.name));
+  const loaded = packDirs.map(loadPack);
+  return resolveLoadedPacks(loaded, enabledPackIds);
+}

--- a/packages/datapack/tsconfig.json
+++ b/packages/datapack/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@dcb/engine",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@dcb/schema": "file:../schema"
+  },
+  "devDependencies": {
+    "vitest": "^2.1.8",
+    "@dcb/datapack": "file:../datapack"
+  }
+}

--- a/packages/engine/src/engine.test.ts
+++ b/packages/engine/src/engine.test.ts
@@ -1,0 +1,73 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { LoadedPack } from "@dcb/datapack";
+import { resolveLoadedPacks, resolvePackSet } from "@dcb/datapack";
+import { finalizeCharacter, initialState, applyChoice, listChoices } from "./index";
+
+const resolved = resolvePackSet(path.resolve(process.cwd(), "../../packs"), ["srd-35e-minimal"]);
+const context = { enabledPackIds: ["srd-35e-minimal"], resolvedData: resolved };
+
+function makePack(id: string, priority: number, dependencies: string[] = []): LoadedPack {
+  return {
+    manifest: { id, name: id, version: "1.0.0", priority, dependencies },
+    entities: {
+      races: [{ id: "human", name: "Human", entityType: "races", effects: [] }],
+      classes: [{ id: "fighter-1", name: "Fighter", entityType: "classes", effects: [] }],
+      feats: [],
+      items: [],
+      skills: [],
+      rules: [{ id: "base-ac", name: "Base AC", entityType: "rules", effects: [{ kind: "set", targetPath: "stats.ac", value: { const: 10 } }] }]
+    },
+    flow: {
+      steps: [
+        { id: "name", kind: "metadata", label: "Name", source: { type: "manual" } },
+        { id: "abilities", kind: "abilities", label: "Ability Scores", source: { type: "manual" } },
+        { id: "race", kind: "race", label: "Race", source: { type: "entityType", entityType: "races", limit: 1 } },
+        { id: "class", kind: "class", label: "Class", source: { type: "entityType", entityType: "classes", limit: 1 } }
+      ]
+    },
+    patches: [],
+    packPath: id
+  };
+}
+
+describe("engine determinism", () => {
+  it("returns identical sheets for same inputs", () => {
+    let state = applyChoice(initialState, "name", "Aric");
+    state = applyChoice(state, "abilities", { str: 16, dex: 12, con: 14, int: 10, wis: 10, cha: 8 });
+    state = applyChoice(state, "race", "human");
+    state = applyChoice(state, "class", "fighter-1");
+    state = applyChoice(state, "feat", ["power-attack"]);
+    state = applyChoice(state, "equipment", ["longsword", "chainmail", "heavy-wooden-shield"]);
+
+    const one = finalizeCharacter(state, context);
+    const two = finalizeCharacter(state, context);
+
+    expect(one).toEqual(two);
+    expect(one.stats.ac).toBe(18);
+    expect(one.stats.attackBonus).toBe(4);
+  });
+
+  it("lists choices", () => {
+    const choices = listChoices(initialState, context);
+    expect(choices.find((c) => c.stepId === "race")?.options[0]?.id).toBe("human");
+  });
+
+  it("uses overriding pack id in provenance records", () => {
+    const base = makePack("base", 1);
+    const override = makePack("override", 2, ["base"]);
+    override.patches = [{ op: "mergeEntity", entityType: "rules", id: "base-ac", value: { effects: [{ kind: "set", targetPath: "stats.ac", value: { const: 15 } }] } }];
+
+    const resolvedOverride = resolveLoadedPacks([base, override], ["override"]);
+    let state = applyChoice(initialState, "name", "Ref");
+    state = applyChoice(state, "abilities", { str: 10, dex: 10, con: 10, int: 10, wis: 10, cha: 10 });
+    state = applyChoice(state, "race", "human");
+    state = applyChoice(state, "class", "fighter-1");
+
+    const sheet = finalizeCharacter(state, { enabledPackIds: ["override"], resolvedData: resolvedOverride });
+    const acSource = sheet.provenance.find((entry) => entry.targetPath === "stats.ac");
+
+    expect(acSource?.setValue).toBe(15);
+    expect(acSource?.source.packId).toBe("override");
+  });
+});

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -1,0 +1,264 @@
+import type { Constraint, Effect, Entity, Expr } from "@dcb/schema";
+
+export interface CharacterState {
+  metadata: { name?: string };
+  abilities: Record<string, number>;
+  selections: Record<string, unknown>;
+}
+
+type ResolvedEntity = Entity & { _source?: { packId: string; version?: string } };
+
+export interface EngineContext {
+  enabledPackIds: string[];
+  resolvedData: {
+    entities: Record<string, Record<string, ResolvedEntity>>;
+    flow: { steps: Array<{ id: string; kind: string; label: string; source: { type: string; entityType?: string; limit?: number } }> };
+    fingerprint: string;
+  };
+  predicates?: Record<string, (state: CharacterState, args?: Record<string, unknown>) => boolean>;
+}
+
+export interface Choice {
+  stepId: string;
+  label: string;
+  options: Array<{ id: string; label: string }>;
+  limit?: number;
+}
+
+export interface ValidationError {
+  code: string;
+  message: string;
+  stepId?: string;
+}
+
+export interface ProvenanceRecord {
+  targetPath: string;
+  delta?: number;
+  setValue?: number;
+  source: { packId: string; entityId: string; choiceStepId?: string };
+}
+
+export interface CharacterSheet {
+  metadata: { name: string };
+  abilities: Record<string, { score: number; mod: number }>;
+  stats: Record<string, number | string>;
+  selections: Record<string, unknown>;
+  provenance: ProvenanceRecord[];
+  packSetFingerprint: string;
+}
+
+function abilityMod(score: number): number {
+  return Math.floor((score - 10) / 2);
+}
+
+function getPath(obj: Record<string, any>, path: string): any {
+  return path.split(".").reduce((acc, k) => acc?.[k], obj);
+}
+
+function setPath(obj: Record<string, any>, path: string, value: number): void {
+  const keys = path.split(".");
+  let current = obj;
+  for (let i = 0; i < keys.length - 1; i += 1) {
+    current[keys[i]] ??= {};
+    current = current[keys[i]];
+  }
+  current[keys[keys.length - 1]] = value;
+}
+
+function evalExpr(expr: Expr, sheet: Record<string, any>): any {
+  if ("const" in expr) return expr.const;
+  if ("path" in expr) return getPath(sheet, expr.path) ?? 0;
+  if ("abilityMod" in expr) return abilityMod(getPath(sheet, `abilities.${expr.abilityMod}.score`) ?? 10);
+  if ("sum" in expr) return expr.sum.reduce((acc, e) => acc + Number(evalExpr(e, sheet)), 0);
+  if ("multiply" in expr) return Number(evalExpr(expr.multiply[0], sheet)) * Number(evalExpr(expr.multiply[1], sheet));
+  if ("if" in expr) return evalExpr(expr.if, sheet) ? evalExpr(expr.then, sheet) : evalExpr(expr.else, sheet);
+  if ("op" in expr) {
+    const left = evalExpr(expr.left, sheet);
+    const right = evalExpr(expr.right, sheet);
+    switch (expr.op) {
+      case "eq": return left === right;
+      case "neq": return left !== right;
+      case "gte": return Number(left) >= Number(right);
+      case "lte": return Number(left) <= Number(right);
+      case "gt": return Number(left) > Number(right);
+      case "lt": return Number(left) < Number(right);
+      case "and": return Boolean(left) && Boolean(right);
+      case "or": return Boolean(left) || Boolean(right);
+      default: return false;
+    }
+  }
+  return 0;
+}
+
+function checkConstraint(constraint: Constraint, state: CharacterState, context: EngineContext): boolean {
+  switch (constraint.kind) {
+    case "requires":
+      return Boolean(evalExpr(constraint.expression, { abilities: Object.fromEntries(Object.entries(state.abilities).map(([k, score]) => [k, { score }])) }));
+    case "levelMin":
+      return ((state.selections.class as string | undefined) ? 1 : 0) >= constraint.level;
+    case "abilityMin":
+      return (state.abilities[constraint.ability] ?? 0) >= constraint.score;
+    case "mutuallyExclusive": {
+      const selectedFeats = (state.selections.feats as string[] | undefined) ?? [];
+      const featEntities = context.resolvedData.entities.feats ?? {};
+      const inGroup = selectedFeats.filter((id) => (featEntities[id]?.data?.exclusiveGroup as string | undefined) === constraint.groupId);
+      return inGroup.length <= 1;
+    }
+    case "predicate":
+      return context.predicates?.[constraint.predicateId]?.(state, constraint.args) ?? true;
+  }
+}
+
+function entityAllowed(entity: Entity, state: CharacterState, context: EngineContext): boolean {
+  return (entity.constraints ?? []).every((constraint) => checkConstraint(constraint, state, context));
+}
+
+export function listChoices(state: CharacterState, context: EngineContext): Choice[] {
+  return context.resolvedData.flow.steps
+    .filter((step) => step.source.type === "entityType" && step.source.entityType)
+    .map((step) => {
+      const options = Object.values(context.resolvedData.entities[step.source.entityType!] ?? {})
+        .filter((entity) => entityAllowed(entity, state, context))
+        .map((entity) => ({ id: entity.id, label: entity.name }));
+      return { stepId: step.id, label: step.label, options, limit: step.source.limit };
+    });
+}
+
+export function applyChoice(state: CharacterState, choiceId: string, selection: unknown): CharacterState {
+  if (choiceId === "name") {
+    return { ...state, metadata: { ...state.metadata, name: String(selection) } };
+  }
+  if (choiceId === "abilities") {
+    return { ...state, abilities: selection as Record<string, number> };
+  }
+  if (choiceId === "feat") {
+    const prev = (state.selections.feats as string[] | undefined) ?? [];
+    const next = Array.from(new Set([...(Array.isArray(selection) ? (selection as string[]) : [...prev, String(selection)])]));
+    return { ...state, selections: { ...state.selections, feats: next } };
+  }
+  return { ...state, selections: { ...state.selections, [choiceId]: selection } };
+}
+
+export function validateState(state: CharacterState, context: EngineContext): ValidationError[] {
+  const errors: ValidationError[] = [];
+  if (!state.metadata.name) errors.push({ code: "NAME_REQUIRED", message: "Character name is required.", stepId: "name" });
+  for (const ability of ["str", "dex", "con", "int", "wis", "cha"]) {
+    const score = state.abilities[ability];
+    if (!Number.isInteger(score) || score < 3 || score > 18) errors.push({ code: "ABILITY_RANGE", message: `${ability.toUpperCase()} must be between 3 and 18.`, stepId: "abilities" });
+  }
+
+  for (const [entityType, entities] of Object.entries(context.resolvedData.entities)) {
+    for (const entity of Object.values(entities)) {
+      if (!entityAllowed(entity, state, context)) {
+        const selected = Object.values(state.selections).flatMap((v) => (Array.isArray(v) ? v : [v]));
+        if (selected.includes(entity.id)) {
+          errors.push({ code: "PREREQ_FAILED", message: `${entity.name} prerequisites not met.`, stepId: entityType });
+        }
+      }
+    }
+  }
+  return errors;
+}
+
+function applyEffect(effect: Effect, sheet: Record<string, any>, provenance: ProvenanceRecord[], source: ProvenanceRecord["source"]): void {
+  if (effect.kind === "conditional") {
+    const branch = evalExpr(effect.condition, sheet) ? effect.then : effect.else ?? [];
+    branch.forEach((child) => applyEffect(child, sheet, provenance, source));
+    return;
+  }
+  const nextValue = Number(evalExpr(effect.value, sheet));
+  const prev = Number(getPath(sheet, effect.targetPath) ?? 0);
+  switch (effect.kind) {
+    case "set":
+    case "derive":
+      setPath(sheet, effect.targetPath, nextValue);
+      provenance.push({ targetPath: effect.targetPath, setValue: nextValue, source });
+      break;
+    case "add": {
+      const value = prev + nextValue;
+      setPath(sheet, effect.targetPath, value);
+      provenance.push({ targetPath: effect.targetPath, delta: nextValue, source });
+      break;
+    }
+    case "multiply": {
+      const value = prev * nextValue;
+      setPath(sheet, effect.targetPath, value);
+      provenance.push({ targetPath: effect.targetPath, setValue: value, source });
+      break;
+    }
+    case "min": {
+      const value = Math.max(prev, nextValue);
+      setPath(sheet, effect.targetPath, value);
+      provenance.push({ targetPath: effect.targetPath, setValue: value, source });
+      break;
+    }
+    case "max": {
+      const value = Math.min(prev, nextValue);
+      setPath(sheet, effect.targetPath, value);
+      provenance.push({ targetPath: effect.targetPath, setValue: value, source });
+      break;
+    }
+  }
+}
+
+export function finalizeCharacter(state: CharacterState, context: EngineContext): CharacterSheet {
+  const abilities = Object.fromEntries(
+    Object.entries(state.abilities).map(([k, score]) => [k, { score, mod: abilityMod(score) }])
+  );
+
+  const sheet: Record<string, any> = {
+    metadata: { name: state.metadata.name ?? "" },
+    abilities,
+    stats: {
+      hp: 0,
+      ac: 10,
+      initiative: 0,
+      speed: 30,
+      bab: 0,
+      fort: 0,
+      ref: 0,
+      will: 0,
+      attackBonus: 0,
+      damageBonus: 0
+    },
+    selections: state.selections
+  };
+
+  const provenance: ProvenanceRecord[] = [];
+
+  const selectedIds = [
+    state.selections.race,
+    state.selections.class,
+    ...((state.selections.feats as string[] | undefined) ?? []),
+    ...((state.selections.equipment as string[] | undefined) ?? [])
+  ].filter(Boolean) as string[];
+
+  for (const entities of Object.values(context.resolvedData.entities)) {
+    for (const entity of Object.values(entities)) {
+      if (selectedIds.includes(entity.id) || entity.entityType === "rules") {
+        for (const effect of entity.effects ?? []) {
+          applyEffect(effect, sheet, provenance, { packId: entity._source?.packId ?? "unknown", entityId: entity.id });
+        }
+      }
+    }
+  }
+
+  sheet.stats.initiative = abilities.dex.mod;
+  sheet.stats.attackBonus = (sheet.stats.bab as number) + abilities.str.mod;
+  sheet.stats.damageBonus = abilities.str.mod;
+
+  return {
+    metadata: { name: sheet.metadata.name },
+    abilities,
+    stats: sheet.stats,
+    selections: state.selections,
+    provenance,
+    packSetFingerprint: context.resolvedData.fingerprint
+  };
+}
+
+export const initialState: CharacterState = {
+  metadata: {},
+  abilities: { str: 10, dex: 10, con: 10, int: 10, wis: 10, cha: 10 },
+  selections: {}
+};

--- a/packages/engine/tsconfig.json
+++ b/packages/engine/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@dcb/schema",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "zod": "^3.24.1"
+  },
+  "devDependencies": {
+    "vitest": "^2.1.8"
+  }
+}

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -1,0 +1,102 @@
+import { z } from "zod";
+
+export const AbilityIdSchema = z.enum(["str", "dex", "con", "int", "wis", "cha"]);
+export type AbilityId = z.infer<typeof AbilityIdSchema>;
+
+export const SourceSchema = z.object({
+  packId: z.string(),
+  entityId: z.string(),
+  choiceStepId: z.string().optional()
+});
+
+export const ExprSchema: z.ZodType<any> = z.lazy(() =>
+  z.union([
+    z.object({ const: z.number() }),
+    z.object({ path: z.string() }),
+    z.object({ abilityMod: AbilityIdSchema }),
+    z.object({ sum: z.array(ExprSchema) }),
+    z.object({ multiply: z.tuple([ExprSchema, ExprSchema]) }),
+    z.object({
+      if: ExprSchema,
+      then: ExprSchema,
+      else: ExprSchema
+    }),
+    z.object({
+      op: z.enum(["eq", "neq", "gte", "lte", "gt", "lt", "and", "or"]),
+      left: ExprSchema,
+      right: ExprSchema
+    })
+  ])
+);
+
+export const EffectSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("add"), targetPath: z.string(), value: ExprSchema }),
+  z.object({ kind: z.literal("set"), targetPath: z.string(), value: ExprSchema }),
+  z.object({ kind: z.literal("multiply"), targetPath: z.string(), value: ExprSchema }),
+  z.object({ kind: z.literal("min"), targetPath: z.string(), value: ExprSchema }),
+  z.object({ kind: z.literal("max"), targetPath: z.string(), value: ExprSchema }),
+  z.object({ kind: z.literal("derive"), targetPath: z.string(), value: ExprSchema }),
+  z.object({ kind: z.literal("conditional"), condition: ExprSchema, then: z.array(z.lazy(() => EffectSchema)), else: z.array(z.lazy(() => EffectSchema)).optional() })
+]);
+
+export const ConstraintSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("requires"), expression: ExprSchema }),
+  z.object({ kind: z.literal("levelMin"), level: z.number().int().min(1) }),
+  z.object({ kind: z.literal("abilityMin"), ability: AbilityIdSchema, score: z.number().int() }),
+  z.object({ kind: z.literal("mutuallyExclusive"), groupId: z.string() }),
+  z.object({ kind: z.literal("predicate"), predicateId: z.string(), args: z.record(z.any()).optional() })
+]);
+
+const ChoiceStepSchema = z.object({
+  id: z.string(),
+  kind: z.enum(["metadata", "abilities", "race", "class", "feat", "equipment"]),
+  label: z.string(),
+  source: z.object({ type: z.enum(["entityType", "manual"]), entityType: z.string().optional(), limit: z.number().int().optional() })
+});
+
+export const ManifestSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  version: z.string(),
+  priority: z.number(),
+  dependencies: z.array(z.string()),
+  compatibleEngineRange: z.string().optional()
+});
+
+export const EntitySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  entityType: z.string(),
+  constraints: z.array(ConstraintSchema).optional(),
+  effects: z.array(EffectSchema).optional(),
+  data: z.record(z.any()).optional()
+});
+
+export const FlowSchema = z.object({ steps: z.array(ChoiceStepSchema) });
+
+export const PackSchema = z.object({
+  manifest: ManifestSchema,
+  entities: z.record(z.array(EntitySchema)),
+  flow: FlowSchema,
+  patches: z.array(z.any()).default([])
+});
+
+export const ContractFixtureSchema = z.object({
+  enabledPacks: z.array(z.string()),
+  initialState: z.record(z.any()),
+  actions: z.array(z.object({ choiceId: z.string(), selection: z.any() })),
+  expected: z.object({
+    availableChoicesContains: z.array(z.string()).optional(),
+    validationErrorCodes: z.array(z.string()).optional(),
+    finalSheetSubset: z.record(z.any()).optional()
+  })
+});
+
+export type Expr = z.infer<typeof ExprSchema>;
+export type Effect = z.infer<typeof EffectSchema>;
+export type Constraint = z.infer<typeof ConstraintSchema>;
+export type Entity = z.infer<typeof EntitySchema>;
+export type Manifest = z.infer<typeof ManifestSchema>;
+export type Flow = z.infer<typeof FlowSchema>;
+export type Pack = z.infer<typeof PackSchema>;
+export type ContractFixture = z.infer<typeof ContractFixtureSchema>;

--- a/packages/schema/src/schema.test.ts
+++ b/packages/schema/src/schema.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { ManifestSchema } from "./index";
+
+describe("manifest schema", () => {
+  it("validates minimal manifest", () => {
+    const parsed = ManifestSchema.parse({
+      id: "srd-35e-minimal",
+      name: "SRD",
+      version: "0.1.0",
+      priority: 10,
+      dependencies: []
+    });
+    expect(parsed.id).toBe("srd-35e-minimal");
+  });
+});

--- a/packages/schema/tsconfig.json
+++ b/packages/schema/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "src/**/*.json"]
+}

--- a/packs/srd-35e-minimal/contracts/happy-path.json
+++ b/packs/srd-35e-minimal/contracts/happy-path.json
@@ -1,0 +1,20 @@
+{
+  "enabledPacks": ["srd-35e-minimal"],
+  "initialState": {},
+  "actions": [
+    { "choiceId": "name", "selection": "Aric" },
+    { "choiceId": "abilities", "selection": { "str": 16, "dex": 12, "con": 14, "int": 10, "wis": 10, "cha": 8 } },
+    { "choiceId": "race", "selection": "human" },
+    { "choiceId": "class", "selection": "fighter-1" },
+    { "choiceId": "feat", "selection": ["power-attack"] },
+    { "choiceId": "equipment", "selection": ["longsword", "chainmail", "heavy-wooden-shield"] }
+  ],
+  "expected": {
+    "availableChoicesContains": ["human", "fighter-1", "power-attack", "chainmail"],
+    "validationErrorCodes": [],
+    "finalSheetSubset": {
+      "metadata": { "name": "Aric" },
+      "stats": { "ac": 18, "bab": 1 }
+    }
+  }
+}

--- a/packs/srd-35e-minimal/entities/classes.json
+++ b/packs/srd-35e-minimal/entities/classes.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": "fighter-1",
+    "name": "Fighter (Level 1)",
+    "entityType": "classes",
+    "effects": [
+      { "kind": "set", "targetPath": "stats.hp", "value": { "sum": [ { "const": 10 }, { "abilityMod": "con" } ] } },
+      { "kind": "set", "targetPath": "stats.bab", "value": { "const": 1 } },
+      { "kind": "set", "targetPath": "stats.fort", "value": { "const": 2 } },
+      { "kind": "set", "targetPath": "stats.ref", "value": { "const": 0 } },
+      { "kind": "set", "targetPath": "stats.will", "value": { "const": 0 } }
+    ]
+  }
+]

--- a/packs/srd-35e-minimal/entities/feats.json
+++ b/packs/srd-35e-minimal/entities/feats.json
@@ -1,0 +1,24 @@
+[
+  {
+    "id": "power-attack",
+    "name": "Power Attack",
+    "entityType": "feats",
+    "constraints": [
+      { "kind": "abilityMin", "ability": "str", "score": 13 },
+      { "kind": "mutuallyExclusive", "groupId": "feat-slot-1" }
+    ],
+    "data": { "exclusiveGroup": "feat-slot-1" }
+  },
+  {
+    "id": "weapon-focus-longsword",
+    "name": "Weapon Focus (Longsword)",
+    "entityType": "feats",
+    "constraints": [
+      { "kind": "mutuallyExclusive", "groupId": "feat-slot-1" }
+    ],
+    "effects": [
+      { "kind": "add", "targetPath": "stats.attackBonus", "value": { "const": 1 } }
+    ],
+    "data": { "exclusiveGroup": "feat-slot-1" }
+  }
+]

--- a/packs/srd-35e-minimal/entities/items.json
+++ b/packs/srd-35e-minimal/entities/items.json
@@ -1,0 +1,25 @@
+[
+  {
+    "id": "longsword",
+    "name": "Longsword",
+    "entityType": "items",
+    "effects": []
+  },
+  {
+    "id": "chainmail",
+    "name": "Chainmail",
+    "entityType": "items",
+    "effects": [
+      { "kind": "add", "targetPath": "stats.ac", "value": { "const": 5 } },
+      { "kind": "set", "targetPath": "stats.speed", "value": { "const": 20 } }
+    ]
+  },
+  {
+    "id": "heavy-wooden-shield",
+    "name": "Heavy Wooden Shield",
+    "entityType": "items",
+    "effects": [
+      { "kind": "add", "targetPath": "stats.ac", "value": { "const": 2 } }
+    ]
+  }
+]

--- a/packs/srd-35e-minimal/entities/races.json
+++ b/packs/srd-35e-minimal/entities/races.json
@@ -1,0 +1,11 @@
+[
+  {
+    "id": "human",
+    "name": "Human",
+    "entityType": "races",
+    "effects": [
+      { "kind": "set", "targetPath": "stats.speed", "value": { "const": 30 } }
+    ],
+    "data": { "size": "medium" }
+  }
+]

--- a/packs/srd-35e-minimal/entities/rules.json
+++ b/packs/srd-35e-minimal/entities/rules.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "base-ac",
+    "name": "Base AC",
+    "entityType": "rules",
+    "effects": [
+      { "kind": "set", "targetPath": "stats.ac", "value": { "sum": [ {"const": 10 }, {"abilityMod": "dex"} ] } }
+    ]
+  },
+  {
+    "id": "initiative",
+    "name": "Initiative",
+    "entityType": "rules",
+    "effects": [
+      { "kind": "set", "targetPath": "stats.initiative", "value": { "abilityMod": "dex" } }
+    ]
+  }
+]

--- a/packs/srd-35e-minimal/entities/skills.json
+++ b/packs/srd-35e-minimal/entities/skills.json
@@ -1,0 +1,8 @@
+[
+  { "id": "spot", "name": "Spot", "entityType": "skills" },
+  { "id": "listen", "name": "Listen", "entityType": "skills" },
+  { "id": "climb", "name": "Climb", "entityType": "skills" },
+  { "id": "jump", "name": "Jump", "entityType": "skills" },
+  { "id": "diplomacy", "name": "Diplomacy", "entityType": "skills" },
+  { "id": "ride", "name": "Ride", "entityType": "skills" }
+]

--- a/packs/srd-35e-minimal/flows/character-creation.flow.json
+++ b/packs/srd-35e-minimal/flows/character-creation.flow.json
@@ -1,0 +1,10 @@
+{
+  "steps": [
+    { "id": "name", "kind": "metadata", "label": "Name", "source": { "type": "manual" } },
+    { "id": "abilities", "kind": "abilities", "label": "Ability Scores", "source": { "type": "manual" } },
+    { "id": "race", "kind": "race", "label": "Race", "source": { "type": "entityType", "entityType": "races", "limit": 1 } },
+    { "id": "class", "kind": "class", "label": "Class", "source": { "type": "entityType", "entityType": "classes", "limit": 1 } },
+    { "id": "feat", "kind": "feat", "label": "Feat", "source": { "type": "entityType", "entityType": "feats", "limit": 1 } },
+    { "id": "equipment", "kind": "equipment", "label": "Equipment", "source": { "type": "entityType", "entityType": "items", "limit": 10 } }
+  ]
+}

--- a/packs/srd-35e-minimal/manifest.json
+++ b/packs/srd-35e-minimal/manifest.json
@@ -1,0 +1,8 @@
+{
+  "id": "srd-35e-minimal",
+  "name": "D&D 3.5e SRD Minimal Pack",
+  "version": "0.1.0",
+  "priority": 10,
+  "dependencies": [],
+  "compatibleEngineRange": ">=0.1.0"
+}

--- a/scripts/extract/README.md
+++ b/scripts/extract/README.md
@@ -1,0 +1,3 @@
+Extraction helper scripts may be added here to transform *licensed SRD reference data you already have* into pack JSON.
+
+This repository does not scrape PDFs and does not include copyrighted rulebook text.

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUncheckedIndexedAccess": true,
+    "noEmit": true,
+    "types": ["node"]
+  }
+}


### PR DESCRIPTION
### Motivation
- Replace pnpm/corepack assumptions with npm workspaces so the repo is runnable in restricted environments and CI uses deterministic npm commands.  
- Remove duplicated pack data in the web app so `/packs` is the single source of truth and the UI reads flow-driven steps.  
- Ensure datapack resolver preserves dependency ordering while still using priority for tie-breaking, and record correct pack provenance for overridden entities.  
- Keep the changes small and verifiable with unit tests that exercise ordering and provenance behavior.

### Description
- Switched root tooling to npm workspaces and replaced `pnpm` usage with npm-friendly scripts in `package.json`, updated `README.md` and `docs` to show `npm` commands, and updated CI to use `actions/setup-node` and `npm ci`/`npm install`.  
- Removed the duplicated in-memory pack data and added `apps/web/src/loadMinimalPack.ts` which imports the JSON files from `packs/srd-35e-minimal` and builds a `LoadedPack` for the web bundle, and updated `apps/web/src/App.tsx` to drive wizard steps from `context.resolvedData.flow.steps` (plus a review step).  
- Adjusted Vite config to allow filesystem access to the monorepo root so the web app can import `/packs` JSON during development.  
- Reworked datapack resolver (`packages/datapack/src/index.ts`) to: do a dependency-preserving topological sort, apply `priority` only to currently-available independent nodes, provide a stable serializer for deterministic fingerprinting, and attach `_source` metadata (`packId` and `version`) to every resolved entity including after patch overrides.  
- Fixed engine provenance in `packages/engine/src/index.ts` so provenance entries use `entity._source.packId` (real source) when recording effect provenance instead of defaulting to an enabled pack id.  
- Added/updated tests: `packages/datapack/src/datapack.test.ts` covers minimal pack loading, dependency-order preservation with priority conflicts, and override source metadata; `packages/engine/src/engine.test.ts` verifies deterministic sheets and that provenance uses the overriding pack id; `apps/web/src/App.test.tsx` exercises the flow-driven web wizard happy path.  
- Rewrote inter-package dev refs from `workspace:*` to `file:` local links so npm workspace installs behave consistently in environments without `workspace:` resolution support.

### Testing
- Attempted automated install with `npm install` but it failed due to external registry access being blocked (`npm ERR 403`), so dependency installation could not complete in this environment.  (failure)  
- Ran `npm test` which failed because test runner binaries were not installed (`vitest: not found`) as a result of the failed install.  (failure)  
- Ran `npm run typecheck` which failed due to missing dev types (e.g. `@types/node`) from the incomplete install.  (failure)  
- Started dev server (`npm run dev`) which failed because `vite` is not available without installed dependencies.  (failure)  
- Unit tests were added to `packages/datapack`, `packages/engine`, and `apps/web` and are expected to pass once `npm install`/`npm ci` succeeds in an environment with registry access; the test suite could not be executed fully here due to the installation blockage.  (not executed)

If you want, I can (1) produce a small lockfile to allow offline installs of the local packages only, or (2) remove external devDependencies to run a subset of tests in this environment; tell me which you prefer.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992833017b8832db5be3d62266de3de)