### PR TITLE
feat(data): add SRD 3.5 core level-1 classes

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -14,6 +14,7 @@ const nextPattern = new RegExp(`${en.next}|${zh.next}`, 'i');
 const reviewPattern = new RegExp(`${en.review}|${zh.review}`, 'i');
 const startWizardPattern = new RegExp(`${en.startWizard}|${zh.startWizard}`, 'i');
 const rulesSetupTitlePattern = new RegExp(`${en.rulesSetupTitle}|${zh.rulesSetupTitle}`, 'i');
+const fighterClassPattern = /Fighter(?: \(Level 1\))?|战士(?:（1级）)?/i;
 
 afterEach(() => {
   cleanup();
@@ -39,7 +40,7 @@ describe('wizard e2e-ish happy path', () => {
     await user.click(screen.getByRole('button', { name: startWizardPattern }));
     await user.click(screen.getByLabelText('Human'));
     await user.click(screen.getByRole('button', { name: nextPattern }));
-    await user.click(screen.getByLabelText('Fighter (Level 1)'));
+    await user.click(screen.getByLabelText(fighterClassPattern));
     await user.click(screen.getByRole('button', { name: nextPattern }));
 
     const strInput = screen.getByLabelText('STR');
@@ -57,7 +58,7 @@ describe('wizard e2e-ish happy path', () => {
 
     expect(screen.getByRole('heading', { name: reviewPattern })).toBeTruthy();
     expect(screen.getByRole('heading', { name: 'AC' })).toBeTruthy();
-    expect(screen.getByText('Fighter (Level 1)', { selector: 'strong' })).toBeTruthy();
+    expect(screen.getByText(fighterClassPattern, { selector: 'strong' })).toBeTruthy();
     expect(screen.getByRole('heading', { name: en.reviewAbilityBreakdown })).toBeTruthy();
     expect(screen.getByRole('heading', { name: en.reviewCombatBreakdown })).toBeTruthy();
     expect(screen.getByRole('heading', { name: en.reviewPackInfo })).toBeTruthy();
@@ -114,7 +115,7 @@ describe('role and language behavior', () => {
       await user.click(screen.getByLabelText('人类'));
       await user.click(screen.getByRole('button', { name: zh.next }));
       expect(screen.getByRole('heading', { name: '职业' })).toBeTruthy();
-      expect(screen.getByLabelText('战士（1级）')).toBeTruthy();
+      expect(screen.getByLabelText(fighterClassPattern)).toBeTruthy();
     });
   });
 
@@ -129,7 +130,7 @@ describe('role and language behavior', () => {
       await user.click(screen.getByLabelText('人类'));
       await user.click(screen.getByRole('button', { name: zh.next }));
 
-      await user.click(screen.getByLabelText('战士（1级）'));
+      await user.click(screen.getByLabelText(fighterClassPattern));
       await user.click(screen.getByRole('button', { name: zh.next }));
 
       expect(screen.getByLabelText('力量')).toBeTruthy();
@@ -150,7 +151,7 @@ describe('role and language behavior', () => {
     expect(screen.getByLabelText(/Human|人类/)).toBeTruthy();
 
     await user.click(screen.getByRole('button', { name: nextPattern }));
-    expect(screen.getByLabelText(/Fighter \(Level 1\)|战士（1级）/)).toBeTruthy();
+    expect(screen.getByLabelText(fighterClassPattern)).toBeTruthy();
 
     await user.click(screen.getByRole('button', { name: new RegExp(`${en.back}|${zh.back}`, 'i') }));
     expect(screen.getByLabelText(/Human|人类/)).toBeTruthy();
@@ -171,7 +172,7 @@ describe('role and language behavior', () => {
       await user.click(screen.getByRole('button', { name: startWizardPattern }));
       await user.click(screen.getByLabelText(/Human|人类/));
       await user.click(screen.getByRole('button', { name: nextPattern }));
-      await user.click(screen.getByLabelText(/Fighter \(Level 1\)|战士（1级）/));
+      await user.click(screen.getByLabelText(fighterClassPattern));
       await user.click(screen.getByRole('button', { name: nextPattern }));
       await user.click(screen.getByRole('button', { name: nextPattern }));
       const featFieldset = screen.getByRole('group', { name: /Feat|专长/i });

--- a/packages/contracts/src/contracts.test.ts
+++ b/packages/contracts/src/contracts.test.ts
@@ -78,6 +78,9 @@ describe("pack contracts", () => {
     const wizard = byId("wizard-1");
     expect(wizard?.data?.classSkills ?? []).not.toContain("diplomacy");
 
+    const druid = byId("druid-1");
+    expect(druid?.data?.classSkills ?? []).not.toContain("climb");
+
     const fighter = byId("fighter-1");
     expect(fighter?.data?.levelTable?.[0]?.features ?? []).toContain("bonus-fighter-feat");
     expect(fighter?.data?.levelTable?.[0]?.specialLabel).toBe("Fighter bonus feat");

--- a/packages/contracts/src/contracts.test.ts
+++ b/packages/contracts/src/contracts.test.ts
@@ -44,4 +44,42 @@ describe("pack contracts", () => {
       fs.rmSync(tempRoot, { recursive: true, force: true });
     }
   });
+
+  it("keeps core SRD 3.5 class details aligned for level-1 class entries", () => {
+    const classesPath = path.resolve(process.cwd(), "../../packs/srd-35e-minimal/entities/classes.json");
+    const classes = JSON.parse(fs.readFileSync(classesPath, "utf8")) as Array<{
+      id: string;
+      data?: {
+        hitDie?: number;
+        classSkills?: string[];
+        levelTable?: Array<{ features?: string[]; specialLabel?: string }>;
+      };
+      effects?: Array<{ kind?: string; targetPath?: string; value?: { const?: number; sum?: Array<{ const?: number }> } }>;
+    }>;
+
+    const byId = (id: string) => classes.find((entry) => entry.id === id);
+    const effectConst = (entry: (typeof classes)[number] | undefined, targetPath: string) =>
+      entry?.effects?.find((effect) => effect.kind === "set" && effect.targetPath === targetPath)?.value?.const ??
+      entry?.effects
+        ?.find((effect) => effect.kind === "set" && effect.targetPath === targetPath)
+        ?.value?.sum?.find((segment) => typeof segment.const === "number")?.const;
+
+    const bard = byId("bard-1");
+    expect(bard?.data?.hitDie).toBe(6);
+    expect(effectConst(bard, "stats.hp")).toBe(6);
+
+    const ranger = byId("ranger-1");
+    expect(ranger?.data?.hitDie).toBe(8);
+    expect(effectConst(ranger, "stats.hp")).toBe(8);
+
+    const sorcerer = byId("sorcerer-1");
+    expect(sorcerer?.data?.classSkills ?? []).not.toContain("diplomacy");
+
+    const wizard = byId("wizard-1");
+    expect(wizard?.data?.classSkills ?? []).not.toContain("diplomacy");
+
+    const fighter = byId("fighter-1");
+    expect(fighter?.data?.levelTable?.[0]?.features ?? []).toContain("bonus-fighter-feat");
+    expect(fighter?.data?.levelTable?.[0]?.specialLabel).toBe("Fighter bonus feat");
+  });
 });

--- a/packages/schema/src/schema.test.ts
+++ b/packages/schema/src/schema.test.ts
@@ -146,7 +146,7 @@ describe("class entity schema", () => {
   it("accepts structured class data", () => {
     const parsed = EntitySchema.parse({
       id: "fighter-1",
-      name: "Fighter (Level 1)",
+      name: "Fighter",
       entityType: "classes",
       summary: "Fighter summary",
       description: "Fighter detail",
@@ -244,7 +244,7 @@ describe("class entity schema", () => {
   it("accepts progression-only class data without levelTable", () => {
     const parsed = EntitySchema.parse({
       id: "rogue-1",
-      name: "Rogue (Level 1)",
+      name: "Rogue",
       entityType: "classes",
       summary: "Rogue summary",
       description: "Rogue detail",

--- a/packs/srd-35e-minimal/authenticity.lock.json
+++ b/packs/srd-35e-minimal/authenticity.lock.json
@@ -1,7 +1,7 @@
 {
   "packId": "srd-35e-minimal",
   "officialRuleset": true,
-  "generatedAt": "2026-02-19T10:16:00.000Z",
+  "generatedAt": "2026-02-19T00:00:00.000Z",
   "generatedBy": "research/srd-authenticity-auto-validation baseline",
   "sourceAuthorities": [
     {
@@ -24,7 +24,7 @@
     },
     {
       "path": "entities/classes.json",
-      "sha256": "92c1df77f2dbeb62788bc0ce6392aea50fb4c139c2c9c0c2db996969695bbb55"
+      "sha256": "76847874d5c1c41fe590f08c5299bc325e7732093b5146618370c99d9d80caea"
     },
     {
       "path": "entities/feats.json",

--- a/packs/srd-35e-minimal/authenticity.lock.json
+++ b/packs/srd-35e-minimal/authenticity.lock.json
@@ -24,7 +24,7 @@
     },
     {
       "path": "entities/classes.json",
-      "sha256": "e9626282cf71f62aad78c79e1ae07bf9059bb771ece8168b4e17d12c125c941d"
+      "sha256": "19265ed508ff4ff554145c4767a2f9f001529ae34529aada87105a496b76727c"
     },
     {
       "path": "entities/feats.json",

--- a/packs/srd-35e-minimal/authenticity.lock.json
+++ b/packs/srd-35e-minimal/authenticity.lock.json
@@ -24,7 +24,7 @@
     },
     {
       "path": "entities/classes.json",
-      "sha256": "19265ed508ff4ff554145c4767a2f9f001529ae34529aada87105a496b76727c"
+      "sha256": "92c1df77f2dbeb62788bc0ce6392aea50fb4c139c2c9c0c2db996969695bbb55"
     },
     {
       "path": "entities/feats.json",

--- a/packs/srd-35e-minimal/authenticity.lock.json
+++ b/packs/srd-35e-minimal/authenticity.lock.json
@@ -24,7 +24,7 @@
     },
     {
       "path": "entities/classes.json",
-      "sha256": "a9bebe35155e1475497f65cdf5f79d4c4410f36b4849fac9ed661bfffc332f71"
+      "sha256": "e9626282cf71f62aad78c79e1ae07bf9059bb771ece8168b4e17d12c125c941d"
     },
     {
       "path": "entities/feats.json",

--- a/packs/srd-35e-minimal/entities/classes.json
+++ b/packs/srd-35e-minimal/entities/classes.json
@@ -1,5 +1,323 @@
 [
   {
+    "id": "barbarian-1",
+    "name": "Barbarian (Level 1)",
+    "entityType": "classes",
+    "data": {
+      "skillPointsPerLevel": 4,
+      "classSkills": [
+        "climb",
+        "jump",
+        "listen",
+        "ride",
+        "spot"
+      ],
+      "hitDie": 12,
+      "baseAttackProgression": "full",
+      "baseSaveProgression": {
+        "fort": "good",
+        "ref": "poor",
+        "will": "poor"
+      },
+      "levelTable": [
+        {
+          "level": 1,
+          "bab": 1,
+          "fort": 2,
+          "ref": 0,
+          "will": 0,
+          "features": [],
+          "specialLabel": "Rage 1/day, fast movement"
+        }
+      ]
+    },
+    "effects": [
+      {
+        "kind": "set",
+        "targetPath": "stats.hp",
+        "value": {
+          "sum": [
+            {
+              "const": 12
+            },
+            {
+              "abilityMod": "con"
+            }
+          ]
+        }
+      },
+      {
+        "kind": "set",
+        "targetPath": "stats.bab",
+        "value": {
+          "const": 1
+        }
+      },
+      {
+        "kind": "set",
+        "targetPath": "stats.fort",
+        "value": {
+          "const": 2
+        }
+      },
+      {
+        "kind": "set",
+        "targetPath": "stats.ref",
+        "value": {
+          "const": 0
+        }
+      },
+      {
+        "kind": "set",
+        "targetPath": "stats.will",
+        "value": {
+          "const": 0
+        }
+      }
+    ],
+    "summary": "Barbarian (Level 1) class option.",
+    "description": "Level 1 barbarian with d12 hit die, full base attack bonus, strong Fortitude save, and martial wilderness skill focus.",
+    "portraitUrl": null,
+    "iconUrl": null
+  },
+  {
+    "id": "bard-1",
+    "name": "Bard (Level 1)",
+    "entityType": "classes",
+    "data": {
+      "skillPointsPerLevel": 6,
+      "classSkills": [
+        "climb",
+        "diplomacy",
+        "jump",
+        "listen",
+        "spot"
+      ],
+      "hitDie": 8,
+      "baseAttackProgression": "threeQuarters",
+      "baseSaveProgression": {
+        "fort": "poor",
+        "ref": "good",
+        "will": "good"
+      },
+      "levelTable": [
+        {
+          "level": 1,
+          "bab": 0,
+          "fort": 0,
+          "ref": 2,
+          "will": 2,
+          "features": [],
+          "specialLabel": "Bardic music, bardic knowledge"
+        }
+      ]
+    },
+    "effects": [
+      {
+        "kind": "set",
+        "targetPath": "stats.hp",
+        "value": {
+          "sum": [
+            {
+              "const": 8
+            },
+            {
+              "abilityMod": "con"
+            }
+          ]
+        }
+      },
+      {
+        "kind": "set",
+        "targetPath": "stats.bab",
+        "value": {
+          "const": 0
+        }
+      },
+      {
+        "kind": "set",
+        "targetPath": "stats.fort",
+        "value": {
+          "const": 0
+        }
+      },
+      {
+        "kind": "set",
+        "targetPath": "stats.ref",
+        "value": {
+          "const": 2
+        }
+      },
+      {
+        "kind": "set",
+        "targetPath": "stats.will",
+        "value": {
+          "const": 2
+        }
+      }
+    ],
+    "summary": "Bard (Level 1) class option.",
+    "description": "Level 1 bard with d8 hit die, 3/4 base attack bonus, strong Reflex and Will saves, and social and perceptive skills.",
+    "portraitUrl": null,
+    "iconUrl": null
+  },
+  {
+    "id": "cleric-1",
+    "name": "Cleric (Level 1)",
+    "entityType": "classes",
+    "data": {
+      "skillPointsPerLevel": 2,
+      "classSkills": [
+        "diplomacy"
+      ],
+      "hitDie": 8,
+      "baseAttackProgression": "threeQuarters",
+      "baseSaveProgression": {
+        "fort": "good",
+        "ref": "poor",
+        "will": "good"
+      },
+      "levelTable": [
+        {
+          "level": 1,
+          "bab": 0,
+          "fort": 2,
+          "ref": 0,
+          "will": 2,
+          "features": [],
+          "specialLabel": "Turn or rebuke undead, domain powers"
+        }
+      ]
+    },
+    "effects": [
+      {
+        "kind": "set",
+        "targetPath": "stats.hp",
+        "value": {
+          "sum": [
+            {
+              "const": 8
+            },
+            {
+              "abilityMod": "con"
+            }
+          ]
+        }
+      },
+      {
+        "kind": "set",
+        "targetPath": "stats.bab",
+        "value": {
+          "const": 0
+        }
+      },
+      {
+        "kind": "set",
+        "targetPath": "stats.fort",
+        "value": {
+          "const": 2
+        }
+      },
+      {
+        "kind": "set",
+        "targetPath": "stats.ref",
+        "value": {
+          "const": 0
+        }
+      },
+      {
+        "kind": "set",
+        "targetPath": "stats.will",
+        "value": {
+          "const": 2
+        }
+      }
+    ],
+    "summary": "Cleric (Level 1) class option.",
+    "description": "Level 1 cleric with d8 hit die, 3/4 base attack bonus, strong Fortitude and Will saves, and divine spellcasting and turning.",
+    "portraitUrl": null,
+    "iconUrl": null
+  },
+  {
+    "id": "druid-1",
+    "name": "Druid (Level 1)",
+    "entityType": "classes",
+    "data": {
+      "skillPointsPerLevel": 4,
+      "classSkills": [
+        "climb",
+        "listen",
+        "spot"
+      ],
+      "hitDie": 8,
+      "baseAttackProgression": "threeQuarters",
+      "baseSaveProgression": {
+        "fort": "good",
+        "ref": "poor",
+        "will": "good"
+      },
+      "levelTable": [
+        {
+          "level": 1,
+          "bab": 0,
+          "fort": 2,
+          "ref": 0,
+          "will": 2,
+          "features": [],
+          "specialLabel": "Nature sense, animal companion"
+        }
+      ]
+    },
+    "effects": [
+      {
+        "kind": "set",
+        "targetPath": "stats.hp",
+        "value": {
+          "sum": [
+            {
+              "const": 8
+            },
+            {
+              "abilityMod": "con"
+            }
+          ]
+        }
+      },
+      {
+        "kind": "set",
+        "targetPath": "stats.bab",
+        "value": {
+          "const": 0
+        }
+      },
+      {
+        "kind": "set",
+        "targetPath": "stats.fort",
+        "value": {
+          "const": 2
+        }
+      },
+      {
+        "kind": "set",
+        "targetPath": "stats.ref",
+        "value": {
+          "const": 0
+        }
+      },
+      {
+        "kind": "set",
+        "targetPath": "stats.will",
+        "value": {
+          "const": 2
+        }
+      }
+    ],
+    "summary": "Druid (Level 1) class option.",
+    "description": "Level 1 druid with d8 hit die, 3/4 base attack bonus, strong Fortitude and Will saves, and nature-themed magic.",
+    "portraitUrl": null,
+    "iconUrl": null
+  },
+  {
     "id": "fighter-1",
     "name": "Fighter (Level 1)",
     "entityType": "classes",
@@ -138,8 +456,482 @@
         }
       }
     ],
-    "summary": "Fighter (Level 1) (class) option.",
-    "description": "Detailed reference entry for Fighter (Level 1) in the classes dataset.",
+    "summary": "Fighter (Level 1) class option.",
+    "description": "Level 1 fighter with d10 hit die, full base attack bonus, strong Fortitude save, and straightforward martial combat focus.",
+    "portraitUrl": null,
+    "iconUrl": null
+  },
+  {
+    "id": "monk-1",
+    "name": "Monk (Level 1)",
+    "entityType": "classes",
+    "data": {
+      "skillPointsPerLevel": 4,
+      "classSkills": [
+        "climb",
+        "jump",
+        "listen",
+        "spot"
+      ],
+      "hitDie": 8,
+      "baseAttackProgression": "threeQuarters",
+      "baseSaveProgression": {
+        "fort": "good",
+        "ref": "good",
+        "will": "good"
+      },
+      "levelTable": [
+        {
+          "level": 1,
+          "bab": 0,
+          "fort": 2,
+          "ref": 2,
+          "will": 2,
+          "features": [],
+          "specialLabel": "Flurry of blows, unarmed strike"
+        }
+      ]
+    },
+    "effects": [
+      {
+        "kind": "set",
+        "targetPath": "stats.hp",
+        "value": {
+          "sum": [
+            {
+              "const": 8
+            },
+            {
+              "abilityMod": "con"
+            }
+          ]
+        }
+      },
+      {
+        "kind": "set",
+        "targetPath": "stats.bab",
+        "value": {
+          "const": 0
+        }
+      },
+      {
+        "kind": "set",
+        "targetPath": "stats.fort",
+        "value": {
+          "const": 2
+        }
+      },
+      {
+        "kind": "set",
+        "targetPath": "stats.ref",
+        "value": {
+          "const": 2
+        }
+      },
+      {
+        "kind": "set",
+        "targetPath": "stats.will",
+        "value": {
+          "const": 2
+        }
+      }
+    ],
+    "summary": "Monk (Level 1) class option.",
+    "description": "Level 1 monk with d8 hit die, 3/4 base attack bonus, all three good saves, and unarmed combat focus.",
+    "portraitUrl": null,
+    "iconUrl": null
+  },
+  {
+    "id": "paladin-1",
+    "name": "Paladin (Level 1)",
+    "entityType": "classes",
+    "data": {
+      "skillPointsPerLevel": 2,
+      "classSkills": [
+        "diplomacy",
+        "ride"
+      ],
+      "hitDie": 10,
+      "baseAttackProgression": "full",
+      "baseSaveProgression": {
+        "fort": "good",
+        "ref": "poor",
+        "will": "poor"
+      },
+      "levelTable": [
+        {
+          "level": 1,
+          "bab": 1,
+          "fort": 2,
+          "ref": 0,
+          "will": 0,
+          "features": [],
+          "specialLabel": "Aura of good, detect evil"
+        }
+      ]
+    },
+    "effects": [
+      {
+        "kind": "set",
+        "targetPath": "stats.hp",
+        "value": {
+          "sum": [
+            {
+              "const": 10
+            },
+            {
+              "abilityMod": "con"
+            }
+          ]
+        }
+      },
+      {
+        "kind": "set",
+        "targetPath": "stats.bab",
+        "value": {
+          "const": 1
+        }
+      },
+      {
+        "kind": "set",
+        "targetPath": "stats.fort",
+        "value": {
+          "const": 2
+        }
+      },
+      {
+        "kind": "set",
+        "targetPath": "stats.ref",
+        "value": {
+          "const": 0
+        }
+      },
+      {
+        "kind": "set",
+        "targetPath": "stats.will",
+        "value": {
+          "const": 0
+        }
+      }
+    ],
+    "summary": "Paladin (Level 1) class option.",
+    "description": "Level 1 paladin with d10 hit die, full base attack bonus, strong Fortitude save, and divine champion flavour.",
+    "portraitUrl": null,
+    "iconUrl": null
+  },
+  {
+    "id": "ranger-1",
+    "name": "Ranger (Level 1)",
+    "entityType": "classes",
+    "data": {
+      "skillPointsPerLevel": 6,
+      "classSkills": [
+        "climb",
+        "jump",
+        "listen",
+        "ride",
+        "spot"
+      ],
+      "hitDie": 10,
+      "baseAttackProgression": "full",
+      "baseSaveProgression": {
+        "fort": "good",
+        "ref": "good",
+        "will": "poor"
+      },
+      "levelTable": [
+        {
+          "level": 1,
+          "bab": 1,
+          "fort": 2,
+          "ref": 2,
+          "will": 0,
+          "features": [],
+          "specialLabel": "Favored enemy, track"
+        }
+      ]
+    },
+    "effects": [
+      {
+        "kind": "set",
+        "targetPath": "stats.hp",
+        "value": {
+          "sum": [
+            {
+              "const": 10
+            },
+            {
+              "abilityMod": "con"
+            }
+          ]
+        }
+      },
+      {
+        "kind": "set",
+        "targetPath": "stats.bab",
+        "value": {
+          "const": 1
+        }
+      },
+      {
+        "kind": "set",
+        "targetPath": "stats.fort",
+        "value": {
+          "const": 2
+        }
+      },
+      {
+        "kind": "set",
+        "targetPath": "stats.ref",
+        "value": {
+          "const": 2
+        }
+      },
+      {
+        "kind": "set",
+        "targetPath": "stats.will",
+        "value": {
+          "const": 0
+        }
+      }
+    ],
+    "summary": "Ranger (Level 1) class option.",
+    "description": "Level 1 ranger with d10 hit die, full base attack bonus, good Fortitude and Reflex saves, and wilderness scouting abilities.",
+    "portraitUrl": null,
+    "iconUrl": null
+  },
+  {
+    "id": "rogue-1",
+    "name": "Rogue (Level 1)",
+    "entityType": "classes",
+    "data": {
+      "skillPointsPerLevel": 8,
+      "classSkills": [
+        "climb",
+        "diplomacy",
+        "jump",
+        "listen",
+        "spot"
+      ],
+      "hitDie": 6,
+      "baseAttackProgression": "threeQuarters",
+      "baseSaveProgression": {
+        "fort": "poor",
+        "ref": "good",
+        "will": "poor"
+      },
+      "levelTable": [
+        {
+          "level": 1,
+          "bab": 0,
+          "fort": 0,
+          "ref": 2,
+          "will": 0,
+          "features": [],
+          "specialLabel": "Sneak attack +1d6, trapfinding"
+        }
+      ]
+    },
+    "effects": [
+      {
+        "kind": "set",
+        "targetPath": "stats.hp",
+        "value": {
+          "sum": [
+            {
+              "const": 6
+            },
+            {
+              "abilityMod": "con"
+            }
+          ]
+        }
+      },
+      {
+        "kind": "set",
+        "targetPath": "stats.bab",
+        "value": {
+          "const": 0
+        }
+      },
+      {
+        "kind": "set",
+        "targetPath": "stats.fort",
+        "value": {
+          "const": 0
+        }
+      },
+      {
+        "kind": "set",
+        "targetPath": "stats.ref",
+        "value": {
+          "const": 2
+        }
+      },
+      {
+        "kind": "set",
+        "targetPath": "stats.will",
+        "value": {
+          "const": 0
+        }
+      }
+    ],
+    "summary": "Rogue (Level 1) class option.",
+    "description": "Level 1 rogue with d6 hit die, 3/4 base attack bonus, strong Reflex save, and a focus on skills and precision attacks.",
+    "portraitUrl": null,
+    "iconUrl": null
+  },
+  {
+    "id": "sorcerer-1",
+    "name": "Sorcerer (Level 1)",
+    "entityType": "classes",
+    "data": {
+      "skillPointsPerLevel": 2,
+      "classSkills": [
+        "diplomacy"
+      ],
+      "hitDie": 4,
+      "baseAttackProgression": "half",
+      "baseSaveProgression": {
+        "fort": "poor",
+        "ref": "poor",
+        "will": "good"
+      },
+      "levelTable": [
+        {
+          "level": 1,
+          "bab": 0,
+          "fort": 0,
+          "ref": 0,
+          "will": 2,
+          "features": [],
+          "specialLabel": "Simple weapon proficiency, spontaneous arcane casting"
+        }
+      ]
+    },
+    "effects": [
+      {
+        "kind": "set",
+        "targetPath": "stats.hp",
+        "value": {
+          "sum": [
+            {
+              "const": 4
+            },
+            {
+              "abilityMod": "con"
+            }
+          ]
+        }
+      },
+      {
+        "kind": "set",
+        "targetPath": "stats.bab",
+        "value": {
+          "const": 0
+        }
+      },
+      {
+        "kind": "set",
+        "targetPath": "stats.fort",
+        "value": {
+          "const": 0
+        }
+      },
+      {
+        "kind": "set",
+        "targetPath": "stats.ref",
+        "value": {
+          "const": 0
+        }
+      },
+      {
+        "kind": "set",
+        "targetPath": "stats.will",
+        "value": {
+          "const": 2
+        }
+      }
+    ],
+    "summary": "Sorcerer (Level 1) class option.",
+    "description": "Level 1 sorcerer with d4 hit die, 1/2 base attack bonus, strong Will save, and spontaneous arcane spellcasting.",
+    "portraitUrl": null,
+    "iconUrl": null
+  },
+  {
+    "id": "wizard-1",
+    "name": "Wizard (Level 1)",
+    "entityType": "classes",
+    "data": {
+      "skillPointsPerLevel": 2,
+      "classSkills": [
+        "diplomacy"
+      ],
+      "hitDie": 4,
+      "baseAttackProgression": "half",
+      "baseSaveProgression": {
+        "fort": "poor",
+        "ref": "poor",
+        "will": "good"
+      },
+      "levelTable": [
+        {
+          "level": 1,
+          "bab": 0,
+          "fort": 0,
+          "ref": 0,
+          "will": 2,
+          "features": [],
+          "specialLabel": "Familiar, prepared arcane casting"
+        }
+      ]
+    },
+    "effects": [
+      {
+        "kind": "set",
+        "targetPath": "stats.hp",
+        "value": {
+          "sum": [
+            {
+              "const": 4
+            },
+            {
+              "abilityMod": "con"
+            }
+          ]
+        }
+      },
+      {
+        "kind": "set",
+        "targetPath": "stats.bab",
+        "value": {
+          "const": 0
+        }
+      },
+      {
+        "kind": "set",
+        "targetPath": "stats.fort",
+        "value": {
+          "const": 0
+        }
+      },
+      {
+        "kind": "set",
+        "targetPath": "stats.ref",
+        "value": {
+          "const": 0
+        }
+      },
+      {
+        "kind": "set",
+        "targetPath": "stats.will",
+        "value": {
+          "const": 2
+        }
+      }
+    ],
+    "summary": "Wizard (Level 1) class option.",
+    "description": "Level 1 wizard with d4 hit die, 1/2 base attack bonus, strong Will save, and prepared arcane spellcasting from a spellbook.",
     "portraitUrl": null,
     "iconUrl": null
   }

--- a/packs/srd-35e-minimal/entities/classes.json
+++ b/packs/srd-35e-minimal/entities/classes.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "barbarian-1",
-    "name": "Barbarian (Level 1)",
+    "name": "Barbarian",
     "entityType": "classes",
     "data": {
       "skillPointsPerLevel": 4,
@@ -75,14 +75,14 @@
         }
       }
     ],
-    "summary": "Barbarian (Level 1) class option.",
+    "summary": "Barbarian class option.",
     "description": "Level 1 barbarian with d12 hit die, full base attack bonus, strong Fortitude save, and martial wilderness skill focus.",
     "portraitUrl": null,
     "iconUrl": null
   },
   {
     "id": "bard-1",
-    "name": "Bard (Level 1)",
+    "name": "Bard",
     "entityType": "classes",
     "data": {
       "skillPointsPerLevel": 6,
@@ -156,14 +156,14 @@
         }
       }
     ],
-    "summary": "Bard (Level 1) class option.",
+    "summary": "Bard class option.",
     "description": "Level 1 bard with d8 hit die, 3/4 base attack bonus, strong Reflex and Will saves, and social and perceptive skills.",
     "portraitUrl": null,
     "iconUrl": null
   },
   {
     "id": "cleric-1",
-    "name": "Cleric (Level 1)",
+    "name": "Cleric",
     "entityType": "classes",
     "data": {
       "skillPointsPerLevel": 2,
@@ -233,14 +233,14 @@
         }
       }
     ],
-    "summary": "Cleric (Level 1) class option.",
+    "summary": "Cleric class option.",
     "description": "Level 1 cleric with d8 hit die, 3/4 base attack bonus, strong Fortitude and Will saves, and divine spellcasting and turning.",
     "portraitUrl": null,
     "iconUrl": null
   },
   {
     "id": "druid-1",
-    "name": "Druid (Level 1)",
+    "name": "Druid",
     "entityType": "classes",
     "data": {
       "skillPointsPerLevel": 4,
@@ -311,14 +311,14 @@
         }
       }
     ],
-    "summary": "Druid (Level 1) class option.",
+    "summary": "Druid class option.",
     "description": "Level 1 druid with d8 hit die, 3/4 base attack bonus, strong Fortitude and Will saves, and nature-themed magic.",
     "portraitUrl": null,
     "iconUrl": null
   },
   {
     "id": "fighter-1",
-    "name": "Fighter (Level 1)",
+    "name": "Fighter",
     "entityType": "classes",
     "data": {
       "skillPointsPerLevel": 2,
@@ -455,14 +455,14 @@
         }
       }
     ],
-    "summary": "Fighter (Level 1) class option.",
+    "summary": "Fighter class option.",
     "description": "Level 1 fighter with d10 hit die, full base attack bonus, strong Fortitude save, and straightforward martial combat focus.",
     "portraitUrl": null,
     "iconUrl": null
   },
   {
     "id": "monk-1",
-    "name": "Monk (Level 1)",
+    "name": "Monk",
     "entityType": "classes",
     "data": {
       "skillPointsPerLevel": 4,
@@ -535,14 +535,14 @@
         }
       }
     ],
-    "summary": "Monk (Level 1) class option.",
+    "summary": "Monk class option.",
     "description": "Level 1 monk with d8 hit die, 3/4 base attack bonus, all three good saves, and unarmed combat focus.",
     "portraitUrl": null,
     "iconUrl": null
   },
   {
     "id": "paladin-1",
-    "name": "Paladin (Level 1)",
+    "name": "Paladin",
     "entityType": "classes",
     "data": {
       "skillPointsPerLevel": 2,
@@ -613,14 +613,14 @@
         }
       }
     ],
-    "summary": "Paladin (Level 1) class option.",
+    "summary": "Paladin class option.",
     "description": "Level 1 paladin with d10 hit die, full base attack bonus, strong Fortitude save, and divine champion flavour.",
     "portraitUrl": null,
     "iconUrl": null
   },
   {
     "id": "ranger-1",
-    "name": "Ranger (Level 1)",
+    "name": "Ranger",
     "entityType": "classes",
     "data": {
       "skillPointsPerLevel": 6,
@@ -694,14 +694,14 @@
         }
       }
     ],
-    "summary": "Ranger (Level 1) class option.",
+    "summary": "Ranger class option.",
     "description": "Level 1 ranger with d10 hit die, full base attack bonus, good Fortitude and Reflex saves, and wilderness scouting abilities.",
     "portraitUrl": null,
     "iconUrl": null
   },
   {
     "id": "rogue-1",
-    "name": "Rogue (Level 1)",
+    "name": "Rogue",
     "entityType": "classes",
     "data": {
       "skillPointsPerLevel": 8,
@@ -775,14 +775,14 @@
         }
       }
     ],
-    "summary": "Rogue (Level 1) class option.",
+    "summary": "Rogue class option.",
     "description": "Level 1 rogue with d6 hit die, 3/4 base attack bonus, strong Reflex save, and a focus on skills and precision attacks.",
     "portraitUrl": null,
     "iconUrl": null
   },
   {
     "id": "sorcerer-1",
-    "name": "Sorcerer (Level 1)",
+    "name": "Sorcerer",
     "entityType": "classes",
     "data": {
       "skillPointsPerLevel": 2,
@@ -850,14 +850,14 @@
         }
       }
     ],
-    "summary": "Sorcerer (Level 1) class option.",
+    "summary": "Sorcerer class option.",
     "description": "Level 1 sorcerer with d4 hit die, 1/2 base attack bonus, strong Will save, and spontaneous arcane spellcasting.",
     "portraitUrl": null,
     "iconUrl": null
   },
   {
     "id": "wizard-1",
-    "name": "Wizard (Level 1)",
+    "name": "Wizard",
     "entityType": "classes",
     "data": {
       "skillPointsPerLevel": 2,
@@ -925,7 +925,7 @@
         }
       }
     ],
-    "summary": "Wizard (Level 1) class option.",
+    "summary": "Wizard class option.",
     "description": "Level 1 wizard with d4 hit die, 1/2 base attack bonus, strong Will save, and prepared arcane spellcasting from a spellbook.",
     "portraitUrl": null,
     "iconUrl": null

--- a/packs/srd-35e-minimal/entities/classes.json
+++ b/packs/srd-35e-minimal/entities/classes.json
@@ -26,10 +26,35 @@
           "fort": 2,
           "ref": 0,
           "will": 0,
-          "features": [],
-          "specialLabel": "Rage 1/day, fast movement"
+          "features": [
+            "rage-1-day",
+            "fast-movement",
+            "illiteracy"
+          ],
+          "specialLabel": "Rage 1/day, fast movement, illiteracy"
         }
-      ]
+      ],
+      "progression": {
+        "levelGains": [
+          {
+            "level": 1,
+            "grants": [
+              {
+                "kind": "grantFeature",
+                "featureId": "rage-1-day"
+              },
+              {
+                "kind": "grantFeature",
+                "featureId": "fast-movement"
+              },
+              {
+                "kind": "grantFeature",
+                "featureId": "illiteracy"
+              }
+            ]
+          }
+        ]
+      }
     },
     "effects": [
       {
@@ -107,10 +132,45 @@
           "fort": 0,
           "ref": 2,
           "will": 2,
-          "features": [],
-          "specialLabel": "Bardic music, bardic knowledge"
+          "features": [
+            "bardic-music",
+            "bardic-knowledge",
+            "countersong",
+            "fascinate",
+            "inspire-courage-1"
+          ],
+          "specialLabel": "Bardic music, bardic knowledge, countersong, fascinate, inspire courage +1"
         }
-      ]
+      ],
+      "progression": {
+        "levelGains": [
+          {
+            "level": 1,
+            "grants": [
+              {
+                "kind": "grantFeature",
+                "featureId": "bardic-music"
+              },
+              {
+                "kind": "grantFeature",
+                "featureId": "bardic-knowledge"
+              },
+              {
+                "kind": "grantFeature",
+                "featureId": "countersong"
+              },
+              {
+                "kind": "grantFeature",
+                "featureId": "fascinate"
+              },
+              {
+                "kind": "grantFeature",
+                "featureId": "inspire-courage-1"
+              }
+            ]
+          }
+        ]
+      }
     },
     "effects": [
       {
@@ -157,7 +217,7 @@
       }
     ],
     "summary": "Bard class option.",
-    "description": "Level 1 bard with d8 hit die, 3/4 base attack bonus, strong Reflex and Will saves, and social and perceptive skills.",
+    "description": "Level 1 bard with d6 hit die, 3/4 base attack bonus, strong Reflex and Will saves, and social and perceptive skills.",
     "portraitUrl": null,
     "iconUrl": null
   },
@@ -184,10 +244,40 @@
           "fort": 2,
           "ref": 0,
           "will": 2,
-          "features": [],
-          "specialLabel": "Turn or rebuke undead, domain powers"
+          "features": [
+            "turn-or-rebuke-undead",
+            "domains",
+            "aura",
+            "spontaneous-cure-inflict"
+          ],
+          "specialLabel": "Turn or rebuke undead, domains, aura, spontaneous cure/inflict casting"
         }
-      ]
+      ],
+      "progression": {
+        "levelGains": [
+          {
+            "level": 1,
+            "grants": [
+              {
+                "kind": "grantFeature",
+                "featureId": "turn-or-rebuke-undead"
+              },
+              {
+                "kind": "grantFeature",
+                "featureId": "domains"
+              },
+              {
+                "kind": "grantFeature",
+                "featureId": "aura"
+              },
+              {
+                "kind": "grantFeature",
+                "featureId": "spontaneous-cure-inflict"
+              }
+            ]
+          }
+        ]
+      }
     },
     "effects": [
       {
@@ -262,10 +352,35 @@
           "fort": 2,
           "ref": 0,
           "will": 2,
-          "features": [],
-          "specialLabel": "Nature sense, animal companion"
+          "features": [
+            "animal-companion",
+            "nature-sense",
+            "wild-empathy"
+          ],
+          "specialLabel": "Animal companion, nature sense, wild empathy"
         }
-      ]
+      ],
+      "progression": {
+        "levelGains": [
+          {
+            "level": 1,
+            "grants": [
+              {
+                "kind": "grantFeature",
+                "featureId": "animal-companion"
+              },
+              {
+                "kind": "grantFeature",
+                "featureId": "nature-sense"
+              },
+              {
+                "kind": "grantFeature",
+                "featureId": "wild-empathy"
+              }
+            ]
+          }
+        ]
+      }
     },
     "effects": [
       {
@@ -486,10 +601,40 @@
           "fort": 2,
           "ref": 2,
           "will": 2,
-          "features": [],
-          "specialLabel": "Flurry of blows, unarmed strike"
+          "features": [
+            "bonus-monk-feat",
+            "flurry-of-blows",
+            "improved-unarmed-strike",
+            "ac-bonus-wisdom"
+          ],
+          "specialLabel": "Bonus monk feat, flurry of blows, improved unarmed strike, AC bonus (Wisdom)"
         }
-      ]
+      ],
+      "progression": {
+        "levelGains": [
+          {
+            "level": 1,
+            "grants": [
+              {
+                "kind": "grantFeature",
+                "featureId": "bonus-monk-feat"
+              },
+              {
+                "kind": "grantFeature",
+                "featureId": "flurry-of-blows"
+              },
+              {
+                "kind": "grantFeature",
+                "featureId": "improved-unarmed-strike"
+              },
+              {
+                "kind": "grantFeature",
+                "featureId": "ac-bonus-wisdom"
+              }
+            ]
+          }
+        ]
+      }
     },
     "effects": [
       {
@@ -564,10 +709,35 @@
           "fort": 2,
           "ref": 0,
           "will": 0,
-          "features": [],
-          "specialLabel": "Aura of good, detect evil"
+          "features": [
+            "aura-of-good",
+            "detect-evil",
+            "smite-evil-1-day"
+          ],
+          "specialLabel": "Aura of good, detect evil, smite evil 1/day"
         }
-      ]
+      ],
+      "progression": {
+        "levelGains": [
+          {
+            "level": 1,
+            "grants": [
+              {
+                "kind": "grantFeature",
+                "featureId": "aura-of-good"
+              },
+              {
+                "kind": "grantFeature",
+                "featureId": "detect-evil"
+              },
+              {
+                "kind": "grantFeature",
+                "featureId": "smite-evil-1-day"
+              }
+            ]
+          }
+        ]
+      }
     },
     "effects": [
       {
@@ -645,10 +815,35 @@
           "fort": 2,
           "ref": 2,
           "will": 0,
-          "features": [],
-          "specialLabel": "Favored enemy, track"
+          "features": [
+            "favored-enemy",
+            "track",
+            "wild-empathy"
+          ],
+          "specialLabel": "Favored enemy, track, wild empathy"
         }
-      ]
+      ],
+      "progression": {
+        "levelGains": [
+          {
+            "level": 1,
+            "grants": [
+              {
+                "kind": "grantFeature",
+                "featureId": "favored-enemy"
+              },
+              {
+                "kind": "grantFeature",
+                "featureId": "track"
+              },
+              {
+                "kind": "grantFeature",
+                "featureId": "wild-empathy"
+              }
+            ]
+          }
+        ]
+      }
     },
     "effects": [
       {
@@ -726,10 +921,30 @@
           "fort": 0,
           "ref": 2,
           "will": 0,
-          "features": [],
+          "features": [
+            "sneak-attack-1d6",
+            "trapfinding"
+          ],
           "specialLabel": "Sneak attack +1d6, trapfinding"
         }
-      ]
+      ],
+      "progression": {
+        "levelGains": [
+          {
+            "level": 1,
+            "grants": [
+              {
+                "kind": "grantFeature",
+                "featureId": "sneak-attack-1d6"
+              },
+              {
+                "kind": "grantFeature",
+                "featureId": "trapfinding"
+              }
+            ]
+          }
+        ]
+      }
     },
     "effects": [
       {
@@ -801,10 +1016,30 @@
           "fort": 0,
           "ref": 0,
           "will": 2,
-          "features": [],
-          "specialLabel": "Simple weapon proficiency, spontaneous arcane casting"
+          "features": [
+            "summon-familiar",
+            "spontaneous-arcane-spellcasting"
+          ],
+          "specialLabel": "Summon familiar, spontaneous arcane spellcasting"
         }
-      ]
+      ],
+      "progression": {
+        "levelGains": [
+          {
+            "level": 1,
+            "grants": [
+              {
+                "kind": "grantFeature",
+                "featureId": "summon-familiar"
+              },
+              {
+                "kind": "grantFeature",
+                "featureId": "spontaneous-arcane-spellcasting"
+              }
+            ]
+          }
+        ]
+      }
     },
     "effects": [
       {
@@ -876,10 +1111,35 @@
           "fort": 0,
           "ref": 0,
           "will": 2,
-          "features": [],
-          "specialLabel": "Familiar, prepared arcane casting"
+          "features": [
+            "summon-familiar",
+            "scribe-scroll",
+            "prepared-arcane-spellcasting"
+          ],
+          "specialLabel": "Summon familiar, Scribe Scroll, prepared arcane spellcasting"
         }
-      ]
+      ],
+      "progression": {
+        "levelGains": [
+          {
+            "level": 1,
+            "grants": [
+              {
+                "kind": "grantFeature",
+                "featureId": "summon-familiar"
+              },
+              {
+                "kind": "grantFeature",
+                "featureId": "scribe-scroll"
+              },
+              {
+                "kind": "grantFeature",
+                "featureId": "prepared-arcane-spellcasting"
+              }
+            ]
+          }
+        ]
+      }
     },
     "effects": [
       {

--- a/packs/srd-35e-minimal/entities/classes.json
+++ b/packs/srd-35e-minimal/entities/classes.json
@@ -93,7 +93,7 @@
         "listen",
         "spot"
       ],
-      "hitDie": 8,
+      "hitDie": 6,
       "baseAttackProgression": "threeQuarters",
       "baseSaveProgression": {
         "fort": "poor",
@@ -119,7 +119,7 @@
         "value": {
           "sum": [
             {
-              "const": 8
+              "const": 6
             },
             {
               "abilityMod": "con"
@@ -632,7 +632,7 @@
         "ride",
         "spot"
       ],
-      "hitDie": 10,
+      "hitDie": 8,
       "baseAttackProgression": "full",
       "baseSaveProgression": {
         "fort": "good",
@@ -658,7 +658,7 @@
         "value": {
           "sum": [
             {
-              "const": 10
+              "const": 8
             },
             {
               "abilityMod": "con"
@@ -787,9 +787,7 @@
     "entityType": "classes",
     "data": {
       "skillPointsPerLevel": 2,
-      "classSkills": [
-        "diplomacy"
-      ],
+      "classSkills": [],
       "hitDie": 4,
       "baseAttackProgression": "half",
       "baseSaveProgression": {
@@ -864,9 +862,7 @@
     "entityType": "classes",
     "data": {
       "skillPointsPerLevel": 2,
-      "classSkills": [
-        "diplomacy"
-      ],
+      "classSkills": [],
       "hitDie": 4,
       "baseAttackProgression": "half",
       "baseSaveProgression": {

--- a/packs/srd-35e-minimal/entities/classes.json
+++ b/packs/srd-35e-minimal/entities/classes.json
@@ -245,7 +245,6 @@
     "data": {
       "skillPointsPerLevel": 4,
       "classSkills": [
-        "climb",
         "listen",
         "spot"
       ],

--- a/packs/srd-35e-minimal/locales/zh.json
+++ b/packs/srd-35e-minimal/locales/zh.json
@@ -20,7 +20,7 @@
       "halfling": "半身人"
     },
     "classes": {
-      "fighter-1": "战士（1级）"
+      "fighter-1": "战士"
     },
     "feats": {
       "power-attack": "强力攻击",
@@ -55,7 +55,7 @@
       "halfling": { "name": "半身人" }
     },
     "classes": {
-      "fighter-1": { "name": "战士（1级）" }
+      "fighter-1": { "name": "战士" }
     },
     "feats": {
       "power-attack": { "name": "强力攻击" },

--- a/packs/srd-35e-minimal/locales/zh.template.json
+++ b/packs/srd-35e-minimal/locales/zh.template.json
@@ -12,9 +12,9 @@
   "entityText": {
     "classes": {
       "fighter-1": {
-        "name": "Fighter (Level 1)",
-        "summary": "Fighter (Level 1) (class) option.",
-        "description": "Detailed reference entry for Fighter (Level 1) in the classes dataset.",
+        "name": "Fighter",
+        "summary": "Fighter (class) option.",
+        "description": "Detailed reference entry for Fighter in the classes dataset.",
         "data.classSkills.0": "climb",
         "data.classSkills.1": "jump",
         "data.classSkills.2": "ride"


### PR DESCRIPTION
## Summary

- Add SRD 3.5 core base classes as level-1 options in packs/srd-35e-minimal/entities/classes.json:
  - barbarian-1, bard-1, cleric-1, druid-1, monk-1, paladin-1, ranger-1, rogue-1, sorcerer-1, wizard-1
- Each class includes canonical level-1 HP/BAB/saves via effects, and forward-looking class metadata in data (hit die, BAB/save progression, level-1 row).

## Notes

- classSkills are currently constrained to the skill IDs present in entities/skills.json (minimal set). A follow-up can expand skills.json to cover full SRD class-skill lists.

## Testing

Blocked locally due to missing CLIs in PATH:
- 
pm test (vitest not found)
- 
pm run contracts (vitest not found)
- 
pm run typecheck / 
pm run lint / 
pm run build (tsc not found)
- 
pm run playwright:install / 
pm run test:visual (playwright not found)


Made with [Cursor](https://cursor.com)