### PR TITLE
docs: define localization MCP scope

### DIFF
--- a/docs/product/DECISIONS.md
+++ b/docs/product/DECISIONS.md
@@ -28,6 +28,17 @@ The flow JSON can specify either manual entry or a point‑buy system. We start 
 
 **Rationale:** Balances guidance for beginners with flexibility for veterans.
 
+### MCP-Based Data Services for Localization and Content Ingestion
+
+We will treat localization and all large-scale data generation as responsibilities of external MCP servers rather than ad-hoc scripts inside the app. MCP services will:
+
+- Extract and translate pack-localizable strings into `PackLocale` data using an official-terms glossary where available.
+- Convert SRD-like structured datasets into our canonical pack format.
+- In future, read rulebook sources (e.g. PDFs) to propose structured entities and flows.
+- Detect mechanics that are not expressible in the current data model and propose schema and flow/review updates instead of hardcoding special cases.
+
+**Rationale:** Keeps the core engine and UI purely data-driven, scales to large and user-uploaded datasets, and centralises complex automation and model evolution logic behind a deterministic service boundary.
+
 ## Pending Decisions (TODO)
 
 - Determine whether to include racial ability adjustments in the point‑buy calculation or apply them separately.
@@ -40,5 +51,6 @@ The flow JSON can specify either manual entry or a point‑buy system. We start 
 - [x] Edition selection decision recorded.
 - [x] Race/class UI decision recorded.
 - [x] Ability method decision recorded.
+- [x] MCP-based localization and data services decision recorded.
 - [ ] Pending decisions listed.
 - [ ] Future decisions to be updated here.

--- a/docs/product/LOCALIZATION_MCP_SCOPE.md
+++ b/docs/product/LOCALIZATION_MCP_SCOPE.md
@@ -1,0 +1,51 @@
+#+ Localization & MCP Services – Scope
+
+This document defines the scope and initial requirements for MCP-based localization and data-generation services that support the DnDCharacterBuilder product.
+
+## Goals
+
+- **Data-driven localization**: Generate and serve `PackLocale` data (starting with zh) for any compatible rule pack, including user-uploaded extensions.
+- **Scalable content ingestion**: Convert SRD-like datasets and, in future, rulebook PDFs into our canonical pack format without hardcoding rules in the UI or engine.
+- **Model evolution support**: Detect mechanics that do not fit the current data model and propose schema and flow/review updates instead of ad-hoc exceptions.
+
+## In-Scope (Phase 1 – Localization MCP)
+
+- **Pack locale extraction**
+  - Input: a resolved pack (manifest, entities, flows).
+  - Output: a locale template that lists all translatable strings as `flowStepLabels` and `entityText[entityType][entityId][path]`.
+  - Must work for both core packs and user-uploaded packs that follow the schema.
+
+- **Locale generation & translation**
+  - Input: a locale template and target language (initially `zh-CN`).
+  - Output: a `PackLocale` object suitable for merging in `resolveLoadedPacks`.
+  - Must:
+    - Apply a curated glossary for official D&D Chinese terminology where available.
+    - Leave untranslated/unknown strings in a safe default (typically English) for later human review.
+    - Be deterministic for the same input template and glossary version.
+
+- **Locale syncing**
+  - Keep locale templates in sync with evolving packs (added/removed entities, renamed fields).
+  - Provide a report of added/removed/changed keys so translators can focus on deltas.
+
+## Future Scope (Not in Phase 1 but Recorded)
+
+- **SRD → Pack conversion MCP**
+  - Import structured SRD datasets and emit packs that conform to `@dcb/schema`.
+  - Support reusable mapping profiles per source (e.g. "3.5e SRD JSON v1").
+
+- **PDF rulebook ingestion**
+  - Read licensing-compliant rulebook PDFs and extract races, classes, feats, items and rules into structured entities and flows.
+  - Flag ambiguous or low-confidence extractions for human review.
+
+- **Data model evolution assistance**
+  - Analyse extracted mechanics to detect gaps in the current data model.
+  - Propose schema updates and corresponding changes to flows and review surfaces in data (no hardcoded UI rules).
+
+## Acceptance Checklist (Phase 1 – Localization MCP)
+
+- [ ] MCP tool can extract a locale template from the existing minimal 3.5e pack.
+- [ ] MCP tool can generate a deterministic `PackLocale` for zh using a glossary.
+- [ ] Engine can merge MCP-produced `PackLocale` with existing pack locales without code changes to the web app.
+- [ ] Localization flow works for at least one user-uploaded pack that follows the same schema.
+- [ ] Documentation updated to describe how product and packs depend on MCP localization.
+

--- a/docs/product/PRD.md
+++ b/docs/product/PRD.md
@@ -28,6 +28,16 @@ Creating a character in D&D can be intimidating. New players are overwhelmed by 
 - Validation and gating for each step.
 - Export of the character sheet with pack fingerprint and provenance.
 
+## Localization & Data Services (MCP)
+
+To support large, extensible datasets and user-provided packs, the product relies on external MCP-based services to automate data generation:
+
+- A localization service that can extract translatable strings from packs and generate `PackLocale` data for supported languages (starting with zh), applying a curated glossary for official D&D terms.
+- A content ingestion service that can convert SRD-like structured data into our pack format, and in future parse rulebooks (e.g. PDFs) into structured entities and flows.
+- A model-evolution service that can analyse new mechanics (e.g. feats, classes, races) that are not representable in the current data model and propose schema and flow/review-surface updates.
+
+These services must keep the engine and UI data-driven and deterministic: packs and locales remain the single source of truth; MCP servers only produce JSON artifacts consumed by the existing engine and web app.
+
 ## Non-Functional Requirements
 
 - Deterministic engine and pure business logic.


### PR DESCRIPTION
## Summary

- Document MCP-based localization and data services in the PRD.
- Record a product decision to treat localization and data generation as MCP responsibilities.
- Add a dedicated scope document for Phase 1 Localization MCP with goals and acceptance checklist.

## Notes

- This PR intentionally changes **docs only**.


Made with [Cursor](https://cursor.com)