### PR TITLE
docs(ui): ability step interaction and allocator design

### DIFF
--- a/docs/ui/components/AbilityAllocator.md
+++ b/docs/ui/components/AbilityAllocator.md
@@ -40,6 +40,16 @@ Suggested effect shape:
 - For each row show: Base, Existing, Final, Derived Modifier.
 - Existing is computed from active `abilityEffects` for that ability.
 
+### Score Controls (Usability Requirements)
+
+- For editable score fields, render adjacent `-` and `+` steppers with large hit areas (minimum 40x40).
+- Click/tap changes by one step; press-and-hold performs repeat stepping for quick adjustments.
+- Keyboard parity:
+  - `ArrowUp` / `ArrowDown` adjust by one step.
+  - Optional accelerated stepping (for example `Shift` + arrow) when consistent with active mode constraints.
+- Buttons must be disabled when constraints would be violated (min/max score, point cap, mode rules).
+- Expose immediate feedback for blocked increments/decrements (disabled affordance + short inline reason).
+
 ### Dynamic Source Groups
 
 - Group row details by `sourceType` (or configured grouping key).
@@ -65,6 +75,7 @@ Suggested effect shape:
 - Desktop/tablet: table-like rows with expandable detail sections.
 - Mobile: card rows with accordion detail panel per ability.
 - Keep headline numbers readable without requiring detail expansion.
+- Keep score steppers directly adjacent to the score value at every breakpoint.
 
 ## Checklist
 

--- a/docs/ux/steps/04_ability_scores.md
+++ b/docs/ux/steps/04_ability_scores.md
@@ -31,6 +31,17 @@ Each ability row displays:
 - Final derived modifier
 - Expand/collapse control for source breakdown
 
+### Score Stepper Ergonomics (Point Buy / Range Inputs)
+
+- Use prominent `-` and `+` steppers beside each score input with a minimum 40x40 hit target (mobile-first).
+- Single tap/click adjusts by 1 step; press-and-hold repeats after a short delay for fast tuning.
+- Support keyboard controls on focused score input:
+  - `ArrowUp` / `ArrowDown`: plus/minus 1
+  - `Shift` + arrow: accelerated stepping (when valid for the mode)
+- Disable stepper buttons when min/max or point-cap constraints would be violated.
+- Keep spent/remaining points visible while stepping so users can adjust without scanning elsewhere.
+- Provide subtle feedback for blocked actions (disabled state + brief reason text near row).
+
 ### Source Breakdown (expandable per ability)
 
 - Group by dynamic `sourceType` values from active effects (for example: race, class, feat, template, rules module, extension content).
@@ -74,6 +85,7 @@ No UI hardcoded defaults for mode rules or modifier source categories.
 - Desktop/tablet: six-row table layout with expandable detail rows.
 - Mobile: stacked row cards (still one card per ability) with details in an accordion panel.
 - Keep key numbers (Base, Existing, Final, Modifier) visible without opening details.
+- Keep `-` and `+` controls pinned next to the editable score on all breakpoints.
 
 ## Acceptance Criteria
 


### PR DESCRIPTION
## Summary\n- define Ability step UI behavior for point buy / PHB / roll sets\n- document data-driven allocator responsibilities\n\n## Scope\n- UI design docs only\n\n## Dependency\n- base: feature/ability-product-docs (must merge first)\n\n## Next Stage\n- UI implementation PR will target this branch as base