### PR TITLE
docs(product): ability generation PRD/scope/journey updates

### DIFF
--- a/docs/plans/2026-02-20-ability-generation-design.md
+++ b/docs/plans/2026-02-20-ability-generation-design.md
@@ -33,6 +33,7 @@ Non-MVP:
 - Edition packs define generation behavior and defaults.
 - MVP must expose all 3 generation modes.
 - Architecture supports edition-specific defaults (for example, 3e and 5e can differ), while MVP implementation targets 3.5 only.
+- No hardcoded fallback defaults for ability generation parameters; missing/invalid config is a data validation error, not a silent fallback.
 - Point-buy cap is customizable in MVP within configured bounds.
 - Full custom table authoring is deferred to later version.
 
@@ -100,6 +101,7 @@ Mode behavior:
 - UI performs immediate guardrails and user feedback.
 - Engine is source of truth for final ability-step validation.
 - Ability validation is driven by flow config, not constants.
+- If required ability-generation config is missing or invalid, engine surfaces explicit config errors and blocks progression.
 - `Next` is gated by ability validation success.
 
 ## 7) Existing Modifiers Visibility
@@ -141,6 +143,7 @@ Risk: Rolling method reproducibility.
 - Engine validates ability selection using config rules.
 - Ability generation rules are loaded from config without hardcoded edition branching, and are validated for the active 3.5 pack in MVP.
 - No hardcoded rule constants for edition behavior in frontend.
+- No hardcoded fallback defaults for ability mode parameters in frontend or engine.
 
 ## 11) Out of Scope
 

--- a/docs/product/MVP_SCOPE.md
+++ b/docs/product/MVP_SCOPE.md
@@ -19,6 +19,7 @@ This document defines the minimal viable product boundaries for the DnDCharacter
    - Point Buy (with configurable point-cap bounds)
    - PHB method
    - Roll Sets (generate 5 sets, pick one)
+   - All defaults/limits/formulas are loaded from pack data (`abilitiesConfig`) with no hardcoded fallback values in UI/engine.
 5. **Feat selection** – limited to feats provided in the minimal pack.
 6. **Skill selection** – simplified 3.5 skill allocation: obey budget and max ranks.
 7. **Equipment selection** – choose items from minimal pack; starting equipment mode recorded.

--- a/docs/product/PRD.md
+++ b/docs/product/PRD.md
@@ -36,6 +36,7 @@ Creating a character in D&D can be intimidating. New players are overwhelmed by 
   2. PHB Method
   3. Roll Sets (generate configured sets and pick one)
 - Rules are edition-bound in architecture: different editions can define different defaults/tables/method parameters in pack data; MVP implementation remains 3.5-only.
+- Default ruleset selection and all mode parameters (enabled modes, default mode, point-buy table/caps, PHB method config, roll-set formula/count) must come from pack-owned flow data, with no code-side fallback constants.
 - Ability step must surface existing modifiers (from currently applied race/class/rules/feats) so users can see effective outcomes during assignment.
 - Point-buy cap must be user-adjustable within configured bounds in MVP.
 - Full custom point-buy table authoring/saving is explicitly non-MVP.

--- a/docs/ux/JOURNEY_OVERVIEW.md
+++ b/docs/ux/JOURNEY_OVERVIEW.md
@@ -23,6 +23,7 @@ Future editions may modify this journey:
 At the Ability Scores step, the user:
 
 1. Chooses generation mode (`Point Buy`, `PHB`, `Roll Sets`) from configured options.
+   - Mode list, default selection, labels, and constraints come from `abilitiesConfig` in pack data (no UI hardcoded defaults).
 2. Completes mode-specific assignment:
    - Point Buy: set scores and point cap, keep total cost within cap.
    - PHB: follow configured PHB rule (for example standard array).


### PR DESCRIPTION
## Summary\n- add product-stage ability generation requirements\n- update MVP scope for edition-bound, data-driven 3-mode ability generation\n- update user journey for Ability step\n\n## Scope\n- docs only (PRD, scope, journey)\n\n## Next Stage\n- UI design PR will target this branch as base