### PR TITLE
[Impl] Narrow authenticity lock scope to canonical entity data

### DIFF
--- a/docs/data/PACK_FORMAT.md
+++ b/docs/data/PACK_FORMAT.md
@@ -22,7 +22,10 @@ packs/<pack-id>/
 ```
 
 For official SRD-derived packs, `authenticity.lock.json` is used by automated tests to verify
-that critical data artifacts match an approved checksum baseline.
+that canonical SRD data artifacts (`entities/*.json`) match an approved checksum baseline.
+
+`flows/*`, `locales/*`, and other presentation/configuration files are intentionally excluded
+from authenticity locks so normal UI/UX iteration does not require lockfile churn.
 
 ## Entity validation
 

--- a/docs/data/SRD_AUTHENTICITY_VALIDATION.md
+++ b/docs/data/SRD_AUTHENTICITY_VALIDATION.md
@@ -11,7 +11,7 @@ An automated lockfile-based integrity check for official packs:
 1. Each official pack can include `authenticity.lock.json`.
 2. The lock records:
    - official source authorities
-   - the expected SHA-256 hash for each critical data artifact
+   - the expected SHA-256 hash for each canonical SRD entity artifact (`entities/*.json`)
 3. `@dcb/contracts` now validates these hashes during test runs.
 4. Any drift in locked files fails CI with a clear checksum mismatch error.
 
@@ -20,6 +20,19 @@ This is enforced by:
 - `packages/contracts/src/authenticity.ts`
 - `packages/contracts/src/contracts.test.ts`
 - `packs/srd-35e-minimal/authenticity.lock.json`
+
+## Scope policy (important)
+
+To reduce false-positive churn, authenticity locks should include only canonical SRD data files:
+
+- `entities/races.json`
+- `entities/classes.json`
+- `entities/feats.json`
+- `entities/items.json`
+- `entities/skills.json`
+- `entities/rules.json`
+
+Do **not** include UI/presentation artifacts like `flows/*` or `locales/*` in authenticity locks.
 
 ## Why this helps
 

--- a/packs/srd-35e-minimal/authenticity.lock.json
+++ b/packs/srd-35e-minimal/authenticity.lock.json
@@ -1,8 +1,8 @@
 {
   "packId": "srd-35e-minimal",
   "officialRuleset": true,
-  "generatedAt": "2026-02-20T22:40:00.000Z",
-  "generatedBy": "ability presentation config update",
+  "generatedAt": "2026-02-24T02:30:00.000Z",
+  "generatedBy": "narrow authenticity scope to canonical entity data only",
   "sourceAuthorities": [
     {
       "title": "D&D 3.5 System Reference Document",
@@ -10,14 +10,6 @@
     }
   ],
   "artifacts": [
-    {
-      "path": "manifest.json",
-      "sha256": "1faa8333e85b7f8fcd1ce7a3d8bf994ca457854594d4830038032539b610a2dc"
-    },
-    {
-      "path": "flows/character-creation.flow.json",
-      "sha256": "fb81d3c843968dd9cc1c107b97ac218a1b704955b593b091d1a91a4719649988"
-    },
     {
       "path": "entities/races.json",
       "sha256": "1484ba60454606a3eee5d4d7934e1264dc1af4b2b3f26a9eccc6162030e89518"


### PR DESCRIPTION
## Summary
- Narrow authenticity lock scope for official SRD packs to canonical entity artifacts only (`entities/*.json`)
- Remove flow/presentation artifact lock coverage to avoid lock churn on UI updates
- Update authenticity docs to codify the new scope policy

## Why
Authenticity checks should guard official SRD data integrity, not block normal UI/UX iteration.

## Validation
- `npm test` (root) ✅
- `@dcb/contracts` authenticity tests ✅

## Changed files
- `packs/srd-35e-minimal/authenticity.lock.json`
- `docs/data/PACK_FORMAT.md`
- `docs/data/SRD_AUTHENTICITY_VALIDATION.md`
