### PR TITLE
feat: expose unresolved rules in character sheets

### DIFF
--- a/docs/plans/2026-03-02-issue-63-unresolved-rules-design.md
+++ b/docs/plans/2026-03-02-issue-63-unresolved-rules-design.md
@@ -1,0 +1,36 @@
+# Issue 63 Unresolved Rules Design
+
+Date: 2026-03-02
+Owner: Engine
+Status: Approved for implementation
+Issue: #63
+
+## Goal
+
+Expose deferred mechanics in final `CharacterSheet` output so selected content cannot silently appear fully implemented when rules are still unresolved.
+
+## Scope
+
+- Add `unresolvedRules` to engine output.
+- Include deterministic IDs, stable ordering, and provenance.
+- Support current deferred metadata shape now and tolerate future normalized `impacts` data without changing the output field name.
+- Add a contract fixture for one known deferred rule path.
+
+## Design
+
+The engine already knows which entities are selected during `finalizeCharacter`. That makes finalization the correct layer to aggregate deferred rule metadata. The output will use this shape:
+
+- `id`
+- `category`
+- `description`
+- `dependsOn`
+- `impacts?`
+- `source`
+
+`impacts` will read from future `impacts` metadata when present, otherwise from current `impactPaths`. Output ordering will be deterministic by a derived ID based on pack, entity type, entity ID, and deferred mechanic ID.
+
+## Non-goals
+
+- No UI changes.
+- No implementation of deferred rules themselves.
+- No normalization of the underlying pack metadata in this PR.

--- a/docs/plans/2026-03-02-issue-63-unresolved-rules-implementation.md
+++ b/docs/plans/2026-03-02-issue-63-unresolved-rules-implementation.md
@@ -1,0 +1,81 @@
+# Issue 63 Unresolved Rules Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add deterministic `unresolvedRules` output to final character sheets and cover it with engine and contract tests.
+
+**Architecture:** Extend engine finalization to collect deferred mechanics from selected entities, normalize them into a stable output record, and return the array on `CharacterSheet`. Keep the output field domain-oriented (`impacts`) while accepting current `impactPaths` data as input compatibility.
+
+**Tech Stack:** TypeScript, Vitest, npm workspaces
+
+---
+
+### Task 1: Add failing engine test
+
+**Files:**
+- Modify: `packages/engine/src/engine.test.ts`
+
+**Step 1: Write the failing test**
+
+Add a test that selects entities with known `deferredMechanics` and expects `finalizeCharacter(...).unresolvedRules` to include deterministic entries with provenance.
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm --workspace @dcb/engine run test -- --runInBand`
+
+Expected: FAIL because `unresolvedRules` does not exist yet.
+
+### Task 2: Add failing contract fixture
+
+**Files:**
+- Create: `packs/srd-35e-minimal/contracts/unresolved-rules.json`
+
+**Step 1: Write the failing fixture**
+
+Create a fixture that selects a known race/feat with deferred mechanics and expects `finalSheetSubset.unresolvedRules` to include at least one entry.
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm --workspace @dcb/contracts run test -- --runInBand`
+
+Expected: FAIL because the final sheet has no `unresolvedRules`.
+
+### Task 3: Implement engine support
+
+**Files:**
+- Modify: `packages/engine/src/index.ts`
+
+**Step 1: Add output types and helpers**
+
+Define `UnresolvedRule` and parse deferred mechanics from selected entities.
+
+**Step 2: Return normalized output**
+
+Map current `impactPaths` or future `impacts` to output `impacts`, include provenance, derive stable IDs, sort deterministically, and include the array in `CharacterSheet`.
+
+**Step 3: Run targeted tests**
+
+Run:
+- `npm --workspace @dcb/engine run test -- --runInBand`
+- `npm --workspace @dcb/contracts run test -- --runInBand`
+
+Expected: PASS
+
+### Task 4: Verify workspace and deliver
+
+**Files:**
+- Modify: `packages/engine/src/index.ts`
+- Modify: `packages/engine/src/engine.test.ts`
+- Create: `packs/srd-35e-minimal/contracts/unresolved-rules.json`
+
+**Step 1: Run full verification**
+
+Run:
+- `npm test`
+- `npm run lint`
+
+**Step 2: Commit**
+
+Run:
+- `git add docs/plans/2026-03-02-issue-63-unresolved-rules-design.md docs/plans/2026-03-02-issue-63-unresolved-rules-implementation.md packages/engine/src/index.ts packages/engine/src/engine.test.ts packs/srd-35e-minimal/contracts/unresolved-rules.json`
+- `git commit -m "feat: expose unresolved rules in character sheets"`

--- a/packages/engine/src/engine.test.ts
+++ b/packages/engine/src/engine.test.ts
@@ -61,6 +61,50 @@ describe("engine determinism", () => {
     expect(one.phase2.movement.adjusted).toBe(20);
   });
 
+  it("surfaces deferred mechanics from selected entities as deterministic unresolved rules", () => {
+    let state = applyChoice(initialState, "name", "Durgan");
+    state = applyChoice(state, "abilities", { str: 16, dex: 12, con: 14, int: 10, wis: 10, cha: 8 });
+    state = applyChoice(state, "race", "dwarf");
+    state = applyChoice(state, "class", "fighter");
+    state = applyChoice(state, "feat", ["acrobatic"]);
+
+    const sheet = finalizeCharacter(state, context);
+
+    expect(sheet.unresolvedRules.map((rule) => rule.id)).toEqual([
+      "srd-35e-minimal:classes:fighter:fighter-bonus-feat-runtime",
+      "srd-35e-minimal:classes:fighter:fighter-proficiency-automation",
+      "srd-35e-minimal:feats:acrobatic:acrobatic-benefit",
+      "srd-35e-minimal:races:dwarf:dwarf-conditional-bonuses",
+      "srd-35e-minimal:races:dwarf:dwarf-weapon-familiarity-proficiency"
+    ]);
+    expect(sheet.unresolvedRules).toEqual(expect.arrayContaining([
+      {
+        id: "srd-35e-minimal:feats:acrobatic:acrobatic-benefit",
+        category: "feat-benefit",
+        description: "GENERAL feat benefit is preserved from source text but not yet enforced by the current engine. You get a +2 bonus on all Jump checks and Tumble checks.",
+        dependsOn: ["feat-effect-engine", "character-sheet-derived-feat-benefits"],
+        impacts: ["selections.feat", "derived.featBenefits"],
+        source: {
+          entityType: "feats",
+          entityId: "acrobatic",
+          packId: "srd-35e-minimal"
+        }
+      },
+      {
+        id: "srd-35e-minimal:races:dwarf:dwarf-weapon-familiarity-proficiency",
+        category: "proficiency",
+        description: "Dwarven weapon familiarity is documented but not enforced by current equipment/proficiency mechanics.",
+        dependsOn: ["equipment-proficiency-model", "equipment-validation-engine"],
+        impacts: ["selections.equipment", "validation.race.proficiency"],
+        source: {
+          entityType: "races",
+          entityId: "dwarf",
+          packId: "srd-35e-minimal"
+        }
+      }
+    ]));
+  });
+
   it("derives equipment load, ACP, and attack classification from entity data", () => {
     const dataDrivenPack: LoadedPack = {
       manifest: { id: "data-driven-pack", name: "DataDrivenPack", version: "1.0.0", priority: 5, dependencies: [] },

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -248,7 +248,32 @@ export interface CharacterSheet {
   phase1: Phase1Sheet;
   phase2: Phase2Sheet;
   provenance: ProvenanceRecord[];
+  unresolvedRules: UnresolvedRule[];
   packSetFingerprint: string;
+}
+
+type DeferredMechanicRecord = {
+  id: string;
+  category: string;
+  description: string;
+  dependsOn: string[];
+  sourceRefs?: string[];
+  impactPaths?: string[];
+  impacts?: string[];
+};
+
+export interface UnresolvedRule {
+  id: string;
+  category: string;
+  description: string;
+  dependsOn: string[];
+  impacts?: string[];
+  source: {
+    entityType: string;
+    entityId: string;
+    packId?: string;
+    sourceRefs?: string[];
+  };
 }
 
 export const DEFAULT_STATS = {
@@ -1201,6 +1226,84 @@ function getEntityDataString(entity: ResolvedEntity | undefined, key: string): s
   return typeof value === "string" ? value.trim() : "";
 }
 
+function parseStringList(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const items = value.map((entry) => String(entry ?? "").trim()).filter(Boolean);
+  return items.length > 0 ? items : undefined;
+}
+
+function parseDeferredMechanics(value: unknown): DeferredMechanicRecord[] {
+  if (!Array.isArray(value)) return [];
+
+  return value.flatMap((entry) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) return [];
+    const record = entry as Record<string, unknown>;
+    const id = String(record.id ?? "").trim();
+    const category = String(record.category ?? "").trim();
+    const description = String(record.description ?? "").trim();
+    const dependsOn = parseStringList(record.dependsOn);
+    if (!id || !category || !description || !dependsOn) return [];
+
+    return [{
+      id,
+      category,
+      description,
+      dependsOn,
+      sourceRefs: parseStringList(record.sourceRefs),
+      impactPaths: parseStringList(record.impactPaths),
+      impacts: parseStringList(record.impacts)
+    }];
+  });
+}
+
+function getSelectedEntities(state: CharacterState, context: EngineContext): ResolvedEntity[] {
+  const entityBuckets = context.resolvedData.entities;
+  const selected: ResolvedEntity[] = [];
+  const seen = new Set<string>();
+
+  function add(entity: ResolvedEntity | undefined): void {
+    if (!entity) return;
+    const key = `${entity._source.packId}:${entity.entityType}:${entity.id}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    selected.push(entity);
+  }
+
+  add(getSelectedRace(state, context));
+  add(getSelectedClass(state, context));
+
+  for (const featId of getSelectedFeatIds(state)) add(entityBuckets.feats?.[featId]);
+  for (const itemId of ((state.selections.equipment as string[] | undefined) ?? [])) add(entityBuckets.items?.[String(itemId)]);
+
+  return selected;
+}
+
+function collectUnresolvedRules(state: CharacterState, context: EngineContext): UnresolvedRule[] {
+  return getSelectedEntities(state, context)
+    .flatMap((entity) =>
+      parseDeferredMechanics(getEntityDataRecord(entity).deferredMechanics).map((mechanic) => ({
+        id: `${entity._source.packId}:${entity.entityType}:${entity.id}:${mechanic.id}`,
+        category: mechanic.category,
+        description: mechanic.description,
+        dependsOn: mechanic.dependsOn,
+        impacts: mechanic.impacts ?? mechanic.impactPaths,
+        source: mechanic.sourceRefs
+          ? {
+              entityType: entity.entityType,
+              entityId: entity.id,
+              packId: entity._source.packId,
+              sourceRefs: mechanic.sourceRefs
+            }
+          : {
+              entityType: entity.entityType,
+              entityId: entity.id,
+              packId: entity._source.packId
+            }
+      }))
+    )
+    .sort((left, right) => left.id.localeCompare(right.id));
+}
+
 function isArmorOrShieldItem(item: ResolvedEntity): boolean {
   const category = getEntityDataString(item, "category").toLowerCase();
   if (category === "armor" || category === "shield") return true;
@@ -1507,6 +1610,7 @@ export function finalizeCharacter(state: CharacterState, context: EngineContext)
         : ["No movement penalty detected."]
     }
   };
+  const unresolvedRules = collectUnresolvedRules(state, context);
 
   return {
     metadata: { name: sheet.metadata.name },
@@ -1518,6 +1622,7 @@ export function finalizeCharacter(state: CharacterState, context: EngineContext)
     phase1,
     phase2,
     provenance,
+    unresolvedRules,
     packSetFingerprint: context.resolvedData.fingerprint
   };
 }

--- a/packs/srd-35e-minimal/contracts/unresolved-rules.json
+++ b/packs/srd-35e-minimal/contracts/unresolved-rules.json
@@ -1,0 +1,53 @@
+{
+  "enabledPacks": [
+    "srd-35e-minimal"
+  ],
+  "initialState": {},
+  "actions": [
+    {
+      "choiceId": "race",
+      "selection": "dwarf"
+    },
+    {
+      "choiceId": "class",
+      "selection": "fighter"
+    },
+    {
+      "choiceId": "abilities",
+      "selection": {
+        "str": 16,
+        "dex": 12,
+        "con": 14,
+        "int": 10,
+        "wis": 10,
+        "cha": 8
+      }
+    },
+    {
+      "choiceId": "feat",
+      "selection": [
+        "acrobatic"
+      ]
+    },
+    {
+      "choiceId": "name",
+      "selection": "Durgan"
+    }
+  ],
+  "expected": {
+    "validationErrorCodes": [],
+    "finalSheetSubset": {
+      "unresolvedRules": [
+        {
+          "id": "srd-35e-minimal:classes:fighter:fighter-bonus-feat-runtime",
+          "category": "class-feature",
+          "source": {
+            "entityType": "classes",
+            "entityId": "fighter",
+            "packId": "srd-35e-minimal"
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add deterministic `unresolvedRules` output to final character sheets
- aggregate deferred mechanics from selected entities with provenance and stable ordering
- add engine coverage and a contract fixture for the new output

## Testing
- npm test
- npm run lint
- npm run typecheck

Closes #63