### PR TITLE
feat(engine): add sheetViewModel for UI-ready output

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -432,14 +432,14 @@ export function App() {
       const selectedClassName = selectedClassId
         ? localizeEntityText('classes', selectedClassId, 'name', context.resolvedData.entities.classes?.[selectedClassId]?.name ?? selectedClassId)
         : '-';
-      const reviewSkills = Object.entries(sheet.skills)
-        .filter(([, skill]) => skill.ranks > 0 || skill.racialBonus !== 0)
+      const combatView = sheet.sheetViewModel.combat;
+      const reviewSkills = sheet.sheetViewModel.skills
+        .filter((skill) => skill.ranks > 0 || skill.racial !== 0)
         .sort((a, b) => {
-          const left = localizeEntityText('skills', a[0], 'name', a[1].name);
-          const right = localizeEntityText('skills', b[0], 'name', b[1].name);
-          return b[1].total - a[1].total || left.localeCompare(right);
+          const left = localizeEntityText('skills', a.id, 'name', a.name);
+          const right = localizeEntityText('skills', b.id, 'name', b.name);
+          return b.total - a.total || left.localeCompare(right);
         });
-      const phase2SkillMap = new Map(phase2.skills.map((skill) => [skill.id, skill]));
       const enabledPackDetails = enabledPackIds.map((packId) => ({
         packId,
         version: packVersionById.get(packId) ?? t.reviewUnknownVersion,
@@ -472,15 +472,15 @@ export function App() {
           <div className="review-stat-cards">
             <article className="review-card">
               <h3>{t.reviewAcLabel}</h3>
-              <p>{String(phase1.combat.ac.total)}</p>
+              <p>{String(combatView.ac.total)}</p>
             </article>
             <article className="review-card">
               <h3>{t.reviewAcTouchLabel}</h3>
-              <p>{String(phase1.combat.ac.touch)}</p>
+              <p>{String(combatView.ac.touch)}</p>
             </article>
             <article className="review-card">
               <h3>{t.reviewAcFlatFootedLabel}</h3>
-              <p>{String(phase1.combat.ac.flatFooted)}</p>
+              <p>{String(combatView.ac.flatFooted)}</p>
             </article>
             <article className="review-card">
               <h3>{t.reviewHpLabel}</h3>
@@ -555,24 +555,14 @@ export function App() {
                 </tr>
               </thead>
               <tbody>
-                {phase1.combat.attacks.melee.map((attack) => (
-                  <tr key={`melee-${attack.itemId}`}>
-                    <td className="review-cell-key">{t.reviewAttackMeleeLabel}</td>
-                    <td>{attack.name}</td>
-                    <td>{formatSigned(attack.attackBonus)}</td>
-                    <td>{attack.damage}</td>
-                    <td>{attack.crit}</td>
-                    <td>-</td>
-                  </tr>
-                ))}
-                {phase1.combat.attacks.ranged.map((attack) => (
-                  <tr key={`ranged-${attack.itemId}`}>
-                    <td className="review-cell-key">{t.reviewAttackRangedLabel}</td>
-                    <td>{attack.name}</td>
-                    <td>{formatSigned(attack.attackBonus)}</td>
-                    <td>{attack.damage}</td>
-                    <td>{attack.crit}</td>
-                    <td>{attack.range ?? '-'}</td>
+                {combatView.attacks.map((attack) => (
+                  <tr key={`${attack.kind}-${attack.weapon.itemId}`}>
+                    <td className="review-cell-key">{attack.kind === 'melee' ? t.reviewAttackMeleeLabel : t.reviewAttackRangedLabel}</td>
+                    <td>{attack.weapon.name}</td>
+                    <td>{formatSigned(attack.attackBonusBreakdown.total)}</td>
+                    <td>{attack.damageLine}</td>
+                    <td>{attack.weapon.crit}</td>
+                    <td>{attack.weapon.range ?? '-'}</td>
                   </tr>
                 ))}
               </tbody>
@@ -729,18 +719,17 @@ export function App() {
                 </tr>
               </thead>
               <tbody>
-                {reviewSkills.map(([skillId, skill]) => {
-                  const phase2Skill = phase2SkillMap.get(skillId);
+                {reviewSkills.map((skill) => {
                   return (
-                    <tr key={skillId}>
-                      <td className="review-cell-key">{localizeEntityText('skills', skillId, 'name', skill.name)}</td>
+                    <tr key={skill.id}>
+                      <td className="review-cell-key">{localizeEntityText('skills', skill.id, 'name', skill.name)}</td>
                       <td>{skill.ranks}</td>
-                      <td>{formatSigned(skill.abilityMod)} ({localizeAbilityLabel(skill.ability)})</td>
-                      <td>{formatSigned(skill.racialBonus)}</td>
-                      <td>{formatSigned(phase2Skill?.misc ?? 0)}</td>
-                      <td>{formatSigned(phase2Skill?.acp ?? 0)}</td>
-                      <td>{phase2Skill?.total ?? skill.total}</td>
-                      <td>{skill.costSpent} ({skill.costPerRank}{t.reviewPerRankUnit})</td>
+                      <td>{formatSigned(skill.ability.value)} ({localizeAbilityLabel(skill.ability.key)})</td>
+                      <td>{formatSigned(skill.racial)}</td>
+                      <td>{formatSigned(skill.misc)}</td>
+                      <td>{formatSigned(skill.acp)}</td>
+                      <td>{skill.total}</td>
+                      <td>{skill.ranks * skill.costPerRank} ({skill.costPerRank}{t.reviewPerRankUnit})</td>
                     </tr>
                   );
                 })}
@@ -1071,42 +1060,100 @@ export function App() {
 
     if (currentStep.kind === 'skills') {
       const selectedRanks = (state.selections[STEP_ID_SKILLS] as Record<string, number> | undefined) ?? {};
+      const skillViewMap = new Map(sheet.sheetViewModel.skills.map((skill) => [skill.id, skill]));
+      const formatSkillValue = (value: number) => `${Number.isInteger(value) ? value : value.toFixed(1)}`;
+      const skillControlLabel = (action: 'increase' | 'decrease', skillName: string) =>
+        language === 'zh'
+          ? `${action === 'increase' ? '提高' : '降低'} ${skillName}`
+          : `${action === 'increase' ? 'Increase' : 'Decrease'} ${skillName}`;
 
       return (
         <section>
           <h2>{currentStep.label}</h2>
-          <p>
+          <p className="skill-points-summary">
             {t.skillsBudgetLabel}: {sheet.decisions.skillPoints.total} | {t.skillsSpentLabel}: {sheet.decisions.skillPoints.spent} | {t.skillsRemainingLabel}: {sheet.decisions.skillPoints.remaining}
           </p>
-          <div className="grid">
-            {skillEntities.map((skill) => {
-              const detail = sheet.skills[skill.id];
-              const ranks = selectedRanks[skill.id] ?? 0;
-              const maxRanks = detail?.maxRanks ?? 2;
-              const classSkill = detail?.classSkill ?? false;
-              const costPerRank = detail?.costPerRank ?? 2;
-              const racialBonus = detail?.racialBonus ?? 0;
-              const inputStep = classSkill ? 1 : 0.5;
+          <div className="skills-table-wrap">
+            <table className="review-table skills-table">
+              <thead>
+                <tr>
+                  <th>{t.reviewSkillColumn}</th>
+                  <th>{language === 'zh' ? '类型' : 'Type'}</th>
+                  <th>{language === 'zh' ? '点数' : 'Points'}</th>
+                  <th>{language === 'zh' ? '等级' : 'Ranks'}</th>
+                  <th>{language === 'zh' ? '明细' : 'Breakdown'}</th>
+                  <th>{t.reviewTotalColumn}</th>
+                  <th>{language === 'zh' ? '备注' : 'Notes'}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {skillEntities.map((skill) => {
+                  const detail = skillViewMap.get(skill.id);
+                  const ranks = selectedRanks[skill.id] ?? 0;
+                  const maxRanks = detail?.maxRanks ?? 2;
+                  const classSkill = detail?.classSkill ?? false;
+                  const costPerRank = detail?.costPerRank ?? 2;
+                  const racialBonus = detail?.racial ?? 0;
+                  const miscBonus = detail?.misc ?? 0;
+                  const acpPenalty = detail?.acp ?? 0;
+                  const abilityMod = detail?.ability.value ?? 0;
+                  const total = detail?.total ?? 0;
+                  const rankStep = classSkill ? 1 : 0.5;
+                  const pointStepCost = rankStep * costPerRank;
+                  const armorCheckPenaltyApplies = detail?.acpApplied ?? Boolean(skill.data?.armorCheckPenaltyApplies);
+                  const canDecrease = ranks > 0;
+                  const canIncrease = (ranks + rankStep) <= maxRanks && sheet.decisions.skillPoints.remaining >= pointStepCost;
 
-              return (
-                <label key={skill.id}>
-                  {skill.displayName} ({classSkill ? t.skillsClassLabel : t.skillsCrossLabel} | {t.skillsCostLabel} {costPerRank}{t.skillsPerRankUnit} | {t.skillsMaxLabel} {maxRanks} | {t.skillsRacialLabel} {racialBonus >= 0 ? '+' : ''}{racialBonus})
-                  <input
-                    type="number"
-                    min={0}
-                    max={maxRanks}
-                    step={inputStep}
-                    value={ranks}
-                    onChange={(e) => {
-                      const parsed = Number(e.target.value);
-                      const value = Number.isFinite(parsed) ? Math.min(maxRanks, Math.max(0, parsed)) : 0;
-                      const nextRanks = { ...selectedRanks, [skill.id]: value };
-                      setState((s) => applyChoice(s, STEP_ID_SKILLS, nextRanks, context));
-                    }}
-                  />
-                </label>
-              );
-            })}
+                  const updateRanks = (nextValue: number) => {
+                    const bounded = Math.min(maxRanks, Math.max(0, nextValue));
+                    const nextRanks = { ...selectedRanks, [skill.id]: bounded };
+                    setState((s) => applyChoice(s, STEP_ID_SKILLS, nextRanks, context));
+                  };
+
+                  return (
+                    <tr key={skill.id}>
+                      <td className="review-cell-key">{skill.displayName}</td>
+                      <td>{classSkill ? t.skillsClassLabel : t.skillsCrossLabel}</td>
+                      <td>{costPerRank}{t.skillsPerRankUnit}</td>
+                      <td>
+                        <div className="skill-rank-stepper">
+                          <button
+                            type="button"
+                            className="ability-step-btn"
+                            aria-label={skillControlLabel('decrease', skill.displayName)}
+                            disabled={!canDecrease}
+                            onClick={() => updateRanks(ranks - rankStep)}
+                          >
+                            -
+                          </button>
+                          <output aria-label={`${skill.displayName} ranks`} className="skill-rank-value">
+                            {formatSkillValue(ranks)}
+                          </output>
+                          <button
+                            type="button"
+                            className="ability-step-btn"
+                            aria-label={skillControlLabel('increase', skill.displayName)}
+                            disabled={!canIncrease}
+                            onClick={() => updateRanks(ranks + rankStep)}
+                          >
+                            +
+                          </button>
+                        </div>
+                      </td>
+                      <td>
+                        {formatSkillValue(ranks)} + {formatSkillValue(abilityMod)} + {formatSkillValue(miscBonus)} - {formatSkillValue(Math.abs(acpPenalty))} = {formatSkillValue(total)}
+                      </td>
+                      <td>{formatSkillValue(total)}</td>
+                      <td>
+                        <div>{t.skillsMaxLabel} {formatSkillValue(maxRanks)}</div>
+                        <div>{t.skillsRacialLabel} {racialBonus >= 0 ? '+' : ''}{formatSkillValue(racialBonus)}</div>
+                        <div>{armorCheckPenaltyApplies ? (language === 'zh' ? '受护甲检定惩罚影响' : 'ACP applies') : (language === 'zh' ? '不受护甲检定惩罚影响' : 'ACP n/a')}</div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
           </div>
         </section>
       );

--- a/packages/engine/src/engine.test.ts
+++ b/packages/engine/src/engine.test.ts
@@ -508,6 +508,178 @@ describe("engine determinism", () => {
     expect(sheet.phase1.combat.attacks.melee[0]?.damage).toBe("1d8");
   });
 
+  it("builds a UI-ready sheetViewModel combat block with AC components and attack breakdowns", () => {
+    const acPack: LoadedPack = {
+      manifest: { id: "viewmodel-pack", name: "ViewModelPack", version: "1.0.0", priority: 5, dependencies: [] },
+      entities: {
+        races: [{
+          id: "human",
+          name: "Human",
+          entityType: "races",
+          summary: "Human",
+          description: "Human race",
+          portraitUrl: null,
+          iconUrl: null,
+          effects: [],
+          data: {
+            size: "medium",
+            baseSpeed: 30,
+            abilityModifiers: {},
+            vision: { lowLight: false, darkvisionFeet: 0 },
+            automaticLanguages: ["Common"],
+            bonusLanguages: [],
+            favoredClass: "any",
+            racialTraits: []
+          }
+        }],
+        classes: [{
+          id: "fighter",
+          name: "Fighter",
+          entityType: "classes",
+          summary: "Fighter",
+          description: "Fighter class",
+          portraitUrl: null,
+          iconUrl: null,
+          effects: [{ kind: "set", targetPath: "stats.bab", value: { const: 1 } }],
+          data: { hitDie: 10, skillPointsPerLevel: 2, classSkills: [] }
+        }],
+        feats: [],
+        items: [
+          {
+            id: "club",
+            name: "Club",
+            entityType: "items",
+            summary: "Simple weapon",
+            description: "Simple weapon",
+            portraitUrl: null,
+            iconUrl: null,
+            effects: [],
+            data: { category: "weapon", weaponType: "melee" }
+          },
+          {
+            id: "shortbow",
+            name: "Shortbow",
+            entityType: "items",
+            summary: "Simple ranged weapon",
+            description: "Simple ranged weapon",
+            portraitUrl: null,
+            iconUrl: null,
+            effects: [],
+            data: { category: "weapon", weaponType: "ranged", damage: "1d6", crit: "x3", range: "60 ft." }
+          },
+          {
+            id: "buckler",
+            name: "Buckler",
+            entityType: "items",
+            summary: "Shield",
+            description: "Shield",
+            portraitUrl: null,
+            iconUrl: null,
+            effects: [{ kind: "add", targetPath: "stats.ac", value: { const: 1 } }],
+            data: { category: "shield", weight: 5 }
+          },
+          {
+            id: "chain-shirt",
+            name: "Chain Shirt",
+            entityType: "items",
+            summary: "Armor",
+            description: "Armor",
+            portraitUrl: null,
+            iconUrl: null,
+            effects: [{ kind: "add", targetPath: "stats.ac", value: { const: 4 } }],
+            data: { category: "armor", weight: 25, armorCheckPenalty: -2 }
+          }
+        ],
+        skills: [],
+        rules: [
+          {
+            id: "base-ac",
+            name: "Base AC",
+            entityType: "rules",
+            summary: "Base AC",
+            description: "Base AC",
+            portraitUrl: null,
+            iconUrl: null,
+            effects: [{ kind: "set", targetPath: "stats.ac", value: { const: 10 } }]
+          },
+          {
+            id: "shield-of-faith",
+            name: "Shield of Faith",
+            entityType: "rules",
+            summary: "Magic AC bonus",
+            description: "Magic AC bonus",
+            portraitUrl: null,
+            iconUrl: null,
+            effects: [{ kind: "add", targetPath: "stats.ac", value: { const: 2 } }]
+          }
+        ]
+      },
+      flow: {
+        steps: [
+          { id: "name", kind: "metadata", label: "Name", source: { type: "manual" } },
+          { id: "abilities", kind: "abilities", label: "Ability Scores", source: { type: "manual" } },
+          { id: "race", kind: "race", label: "Race", source: { type: "entityType", entityType: "races", limit: 1 } },
+          { id: "class", kind: "class", label: "Class", source: { type: "entityType", entityType: "classes", limit: 1 } }
+        ]
+      },
+      patches: [],
+      packPath: "viewmodel-pack"
+    };
+    const localContext = {
+      enabledPackIds: ["viewmodel-pack"],
+      resolvedData: resolveLoadedPacks([makePack("base", 1), acPack], ["viewmodel-pack"])
+    };
+
+    let state = applyChoice(initialState, "name", "View");
+    state = applyChoice(state, "abilities", { str: 14, dex: 12, con: 10, int: 10, wis: 10, cha: 10 });
+    state = applyChoice(state, "race", "human");
+    state = applyChoice(state, "class", "fighter");
+    state = applyChoice(state, "equipment", ["club", "shortbow", "buckler", "chain-shirt"]);
+
+    const sheet = finalizeCharacter(state, localContext);
+    const ac = sheet.sheetViewModel.combat.ac;
+    const meleeAttack = sheet.sheetViewModel.combat.attacks.find((attack) => attack.kind === "melee");
+    const rangedAttack = sheet.sheetViewModel.combat.attacks.find((attack) => attack.kind === "ranged");
+
+    expect(ac.total).toBe(18);
+    expect(ac.touch).toBe(13);
+    expect(ac.flatFooted).toBe(17);
+    expect(ac.components).toEqual([
+      { label: "Base", value: 10 },
+      { label: "Armor", value: 4 },
+      { label: "Shield", value: 1 },
+      { label: "Dex", value: 1 },
+      { label: "Size", value: 0 },
+      { label: "Natural", value: 0 },
+      { label: "Deflection", value: 0 },
+      { label: "Misc", value: 2 }
+    ]);
+    expect(meleeAttack).toMatchObject({
+      weapon: { itemId: "club", name: "Club", crit: "x2" },
+      attackBonus: 3,
+      attackBonusBreakdown: {
+        total: 3,
+        ability: { key: "str", value: 2 },
+        bab: 1,
+        size: 0,
+        misc: 0
+      },
+      damageLine: "1d8+2"
+    });
+    expect(rangedAttack).toMatchObject({
+      weapon: { itemId: "shortbow", name: "Shortbow", crit: "x3", range: "60 ft." },
+      attackBonus: 2,
+      attackBonusBreakdown: {
+        total: 2,
+        ability: { key: "dex", value: 1 },
+        bab: 1,
+        size: 0,
+        misc: 0
+      },
+      damageLine: "1d6"
+    });
+  });
+
   it("omits +0 in unarmed fallback damage", () => {
     let state = applyChoice(initialState, "name", "Unarmed");
     state = applyChoice(state, "abilities", { str: 10, dex: 10, con: 10, int: 10, wis: 10, cha: 10 });
@@ -1005,6 +1177,93 @@ describe("engine determinism", () => {
 
     const errors = validateState(state, context);
     expect(errors.some((error) => error.code === "SKILL_POINTS_EXCEEDED")).toBe(true);
+  });
+
+  it("builds a legal fighter skill allocation with class and cross-class costs in the breakdown", () => {
+    let state = applyChoice(initialState, "name", "SkillMath");
+    state = applyChoice(state, "abilities", { str: 14, dex: 12, con: 10, int: 10, wis: 10, cha: 8 });
+    state = applyChoice(state, "race", "human");
+    state = applyChoice(state, "class", "fighter");
+    state = applyChoice(state, "equipment", ["chainmail"], context);
+    state = applyChoice(state, "skills", { climb: 4, jump: 3, diplomacy: 0.5 }, context);
+
+    const errors = validateState(state, context);
+    const sheet = finalizeCharacter(state, context);
+    const climb = sheet.skills.climb;
+    const diplomacy = sheet.skills.diplomacy;
+    const phase2Climb = sheet.phase2.skills.find((skill) => skill.id === "climb");
+
+    expect(errors).toEqual([]);
+    expect(sheet.decisions.skillPoints.total).toBe(12);
+    expect(sheet.decisions.skillPoints.spent).toBe(8);
+    expect(sheet.decisions.skillPoints.remaining).toBe(4);
+    expect(climb).toMatchObject({
+      classSkill: true,
+      ranks: 4,
+      costPerRank: 1,
+      costSpent: 4,
+      abilityMod: 2,
+      total: 6
+    });
+    expect(diplomacy).toMatchObject({
+      classSkill: false,
+      ranks: 0.5,
+      costPerRank: 2,
+      costSpent: 1,
+      abilityMod: -1,
+      total: -0.5
+    });
+    expect(phase2Climb).toMatchObject({
+      ranks: 4,
+      ability: 2,
+      misc: 0,
+      acp: -5,
+      total: 1
+    });
+  });
+
+  it("builds a UI-ready sheetViewModel skills list with ability, misc, and ACP applicability", () => {
+    let state = applyChoice(initialState, "name", "SkillView");
+    state = applyChoice(state, "abilities", { str: 14, dex: 12, con: 10, int: 10, wis: 10, cha: 8 });
+    state = applyChoice(state, "race", "half-elf");
+    state = applyChoice(state, "class", "fighter");
+    state = applyChoice(state, "feat", ["acrobatic"]);
+    state = applyChoice(state, "equipment", ["chainmail"], context);
+    state = applyChoice(state, "skills", { climb: 4, diplomacy: 0.5, jump: 1 }, context);
+
+    const sheet = finalizeCharacter(state, context);
+    const climb = sheet.sheetViewModel.skills.find((skill) => skill.id === "climb");
+    const diplomacy = sheet.sheetViewModel.skills.find((skill) => skill.id === "diplomacy");
+    const jump = sheet.sheetViewModel.skills.find((skill) => skill.id === "jump");
+
+    expect(climb).toMatchObject({
+      id: "climb",
+      ranks: 4,
+      ability: { key: "str", value: 2 },
+      misc: 0,
+      acp: -5,
+      acpApplied: true,
+      total: 1
+    });
+    expect(diplomacy).toMatchObject({
+      id: "diplomacy",
+      ranks: 0.5,
+      ability: { key: "cha", value: -1 },
+      misc: 0,
+      racial: 2,
+      acp: 0,
+      acpApplied: false,
+      total: 1.5
+    });
+    expect(jump).toMatchObject({
+      id: "jump",
+      ranks: 1,
+      ability: { key: "str", value: 2 },
+      misc: 2,
+      acp: -5,
+      acpApplied: true,
+      total: 0
+    });
   });
 
   it("returns STEP_LIMIT_EXCEEDED when selections exceed dynamic feat limit", () => {

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -238,6 +238,62 @@ export interface Phase2Sheet {
   };
 }
 
+export interface SheetViewModel {
+  combat: {
+    ac: {
+      total: number;
+      touch: number;
+      flatFooted: number;
+      components: Array<{
+        label: string;
+        value: number;
+      }>;
+    };
+    attacks: Array<{
+      kind: "melee" | "ranged";
+      weapon: {
+        itemId: string;
+        name: string;
+        crit: string;
+        range?: string;
+      };
+      attackBonus: number;
+      attackBonusBreakdown: {
+        total: number;
+        bab: number;
+        ability: {
+          key: AbilityKey;
+          value: number;
+        };
+        size: number;
+        misc: number;
+        components: Array<{
+          label: string;
+          value: number;
+        }>;
+      };
+      damageLine: string;
+    }>;
+  };
+  skills: Array<{
+    id: string;
+    name: string;
+    ranks: number;
+    ability: {
+      key: AbilityKey;
+      value: number;
+    };
+    racial: number;
+    misc: number;
+    acp: number;
+    acpApplied: boolean;
+    total: number;
+    classSkill: boolean;
+    costPerRank: number;
+    maxRanks: number;
+  }>;
+}
+
 export interface CharacterSheet {
   metadata: { name: string };
   abilities: Record<string, { score: number; mod: number }>;
@@ -247,6 +303,7 @@ export interface CharacterSheet {
   decisions: DecisionSummary;
   phase1: Phase1Sheet;
   phase2: Phase2Sheet;
+  sheetViewModel: SheetViewModel;
   provenance: ProvenanceRecord[];
   unresolvedRules: UnresolvedRule[];
   packSetFingerprint: string;
@@ -1338,6 +1395,131 @@ function formatDamageWithModifier(baseDamage: string, modifier: number): string 
   return `${baseDamage}${modifier > 0 ? "+" : ""}${modifier}`;
 }
 
+function buildAcComponents(ac: Phase1Sheet["combat"]["ac"]): SheetViewModel["combat"]["ac"]["components"] {
+  return [
+    { label: "Base", value: 10 },
+    { label: "Armor", value: ac.breakdown.armor },
+    { label: "Shield", value: ac.breakdown.shield },
+    { label: "Dex", value: ac.breakdown.dex },
+    { label: "Size", value: ac.breakdown.size },
+    { label: "Natural", value: ac.breakdown.natural },
+    { label: "Deflection", value: ac.breakdown.deflection },
+    { label: "Misc", value: ac.breakdown.misc }
+  ];
+}
+
+function buildAcViewModel(ac: Phase1Sheet["combat"]["ac"]): SheetViewModel["combat"]["ac"] {
+  const components = buildAcComponents(ac);
+  const total = components.reduce((sum, component) => sum + component.value, 0);
+  const touch = total - ac.breakdown.armor - ac.breakdown.shield - ac.breakdown.natural;
+  const flatFooted = total - Math.max(ac.breakdown.dex, 0);
+
+  return {
+    total,
+    touch,
+    flatFooted,
+    components
+  };
+}
+
+function buildAttackBonusBreakdown(
+  kind: "melee" | "ranged",
+  bab: number,
+  abilities: Record<string, { score: number; mod: number }>,
+  sizeModifier: number,
+  misc = 0
+): SheetViewModel["combat"]["attacks"][number]["attackBonusBreakdown"] {
+  const abilityKey: AbilityKey = kind === "ranged" ? "dex" : "str";
+  const abilityValue = abilities[abilityKey]?.mod ?? 0;
+  const total = bab + abilityValue + sizeModifier + misc;
+
+  return {
+    total,
+    bab,
+    ability: {
+      key: abilityKey,
+      value: abilityValue
+    },
+    size: sizeModifier,
+    misc,
+    components: [
+      { label: "BAB", value: bab },
+      { label: abilityKey.toUpperCase(), value: abilityValue },
+      { label: "Size", value: sizeModifier },
+      { label: "Misc", value: misc }
+    ]
+  };
+}
+
+function buildSheetViewModel(
+  phase1: Phase1Sheet,
+  skills: Record<string, SkillBreakdown>,
+  entityBuckets: ResolvedPackSet["entities"],
+  acpPenalty: number,
+  abilities: Record<string, { score: number; mod: number }>,
+  decisions: DecisionSummary,
+  bab: number
+): SheetViewModel {
+  const attacks: SheetViewModel["combat"]["attacks"] = [
+    ...phase1.combat.attacks.melee.map((attack) => ({
+      kind: "melee" as const,
+      weapon: {
+        itemId: attack.itemId,
+        name: attack.name,
+        crit: attack.crit
+      },
+      attackBonus: attack.attackBonus,
+      attackBonusBreakdown: buildAttackBonusBreakdown("melee", bab, abilities, decisions.sizeModifiers.attack),
+      damageLine: attack.damage
+    })),
+    ...phase1.combat.attacks.ranged.map((attack) => ({
+      kind: "ranged" as const,
+      weapon: {
+        itemId: attack.itemId,
+        name: attack.name,
+        crit: attack.crit,
+        range: attack.range
+      },
+      attackBonus: attack.attackBonus,
+      attackBonusBreakdown: buildAttackBonusBreakdown("ranged", bab, abilities, decisions.sizeModifiers.attack),
+      damageLine: attack.damage
+    }))
+  ];
+
+  const skillRows = Object.entries(skills)
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([skillId, skill]) => {
+      const skillEntity = entityBuckets.skills?.[skillId];
+      const acpApplied = skillIsAffectedByArmorCheckPenalty(skillEntity);
+      const acp = acpApplied ? acpPenalty : 0;
+      return {
+        id: skillId,
+        name: skill.name,
+        ranks: skill.ranks,
+        ability: {
+          key: skill.ability,
+          value: skill.abilityMod
+        },
+        racial: skill.racialBonus,
+        misc: skill.miscBonus,
+        acp,
+        acpApplied,
+        total: skill.total + acp,
+        classSkill: skill.classSkill,
+        costPerRank: skill.costPerRank,
+        maxRanks: skill.maxRanks
+      };
+    });
+
+  return {
+    combat: {
+      ac: buildAcViewModel(phase1.combat.ac),
+      attacks
+    },
+    skills: skillRows
+  };
+}
+
 export function finalizeCharacter(state: CharacterState, context: EngineContext): CharacterSheet {
   const abilities = Object.fromEntries(
     Object.entries(state.abilities).map(([k, score]) => [k, { score, mod: abilityMod(score) }])
@@ -1611,6 +1793,7 @@ export function finalizeCharacter(state: CharacterState, context: EngineContext)
     }
   };
   const unresolvedRules = collectUnresolvedRules(state, context);
+  const sheetViewModel = buildSheetViewModel(phase1, skills, entityBuckets, acpPenalty, finalAbilities, decisions, bab);
 
   return {
     metadata: { name: sheet.metadata.name },
@@ -1621,6 +1804,7 @@ export function finalizeCharacter(state: CharacterState, context: EngineContext)
     decisions,
     phase1,
     phase2,
+    sheetViewModel,
     provenance,
     unresolvedRules,
     packSetFingerprint: context.resolvedData.fingerprint


### PR DESCRIPTION
Issue #81: Implement sheetViewModel output in engine

## Summary
- Add SheetViewModel interface with combat (AC breakdown, touch, flat-footed, attacks) and skills
- Add buildSheetViewModel() function to generate UI-ready structure
- Update finalizeCharacter() to include sheetViewModel in output
- Update React App.tsx to render from sheetViewModel instead of recomputing

## Acceptance
UI renders from sheetViewModel without recomputing logic in React.

Closes #81