### PR TITLE
feat(engine): add sheetViewModel for UI-ready output

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -52,7 +52,7 @@ async function reachSkillsStep(user: ReturnType<typeof userEvent.setup>) {
   await user.clear(dexInput);
   await user.type(dexInput, '12');
 
-  const intInput = screen.getByRole('spinbutton', { name: /INT|智力/i });
+  const intInput = screen.getByLabelText(/INT|智力/i, { selector: '#ability-input-int' });
   await user.clear(intInput);
   await user.type(intInput, '10');
 
@@ -113,6 +113,23 @@ describe('wizard e2e-ish happy path', () => {
     expect(screen.getAllByText(/Chainmail/i).length).toBeGreaterThan(0);
     expect(screen.getByText(new RegExp(en.reviewFingerprintLabel, 'i'))).toBeTruthy();
     expect(document.body.textContent).toMatch(/[a-f0-9]{64}/);
+  });
+
+  it('renders review skill rows with a closed ability label parenthesis', async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await reachSkillsStep(user);
+
+    const climbRow = screen.getByRole('row', { name: climbSkillPattern });
+    await user.click(within(climbRow).getByRole('button', { name: /Increase|鎻愰珮/i }));
+    await user.click(screen.getByRole('button', { name: nextPattern }));
+    await user.click(screen.getByLabelText(/Longsword|闀垮墤/i));
+    await user.click(screen.getByRole('button', { name: nextPattern }));
+    await user.type(screen.getByLabelText(new RegExp(`${en.nameLabel}|${zh.nameLabel}`, 'i')), 'Aric');
+    await user.click(screen.getByRole('button', { name: nextPattern }));
+
+    expect(screen.getByText(/\(\s*(?:STR|鍔涢噺)\s*\)/i)).toBeTruthy();
   });
 });
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -980,7 +980,7 @@ export function App() {
                       <td>{skill.ranks}</td>
                       <td>
                         {formatSigned(skill.abilityMod)} (
-                        {localizeAbilityLabel(skill.abilityKey)}
+                        {localizeAbilityLabel(skill.abilityKey)})
                       </td>
                       <td>{formatSigned(detail?.racialBonus ?? 0)}</td>
                       <td>{formatSigned(skill.misc)}</td>

--- a/packages/engine/src/engine.test.ts
+++ b/packages/engine/src/engine.test.ts
@@ -132,6 +132,104 @@ describe("sheetViewModel", () => {
       ])
     );
   });
+
+  it("uses attack size modifier instead of AC size modifier in attack breakdowns", () => {
+    const sizePack: LoadedPack = {
+      manifest: { id: "size-pack", name: "SizePack", version: "1.0.0", priority: 5, dependencies: [] },
+      entities: {
+        races: [{
+          id: "tinyling",
+          name: "Tinyling",
+          entityType: "races",
+          summary: "Tinyling",
+          description: "Tinyling race",
+          portraitUrl: null,
+          iconUrl: null,
+          effects: [],
+          data: {
+            size: "small",
+            baseSpeed: 20,
+            abilityModifiers: {},
+            vision: { lowLight: false, darkvisionFeet: 0 },
+            automaticLanguages: ["Common"],
+            bonusLanguages: [],
+            favoredClass: "any",
+            racialTraits: [],
+            sizeModifiers: { ac: 2, attack: 1, hide: 8, carryingCapacityMultiplier: 0.5 }
+          }
+        }],
+        classes: [{
+          id: "fighter",
+          name: "Fighter",
+          entityType: "classes",
+          summary: "Fighter",
+          description: "Fighter class",
+          portraitUrl: null,
+          iconUrl: null,
+          effects: [{ kind: "set", targetPath: "stats.bab", value: { const: 1 } }],
+          data: { hitDie: 10, skillPointsPerLevel: 2, classSkills: [] }
+        }],
+        feats: [],
+        items: [{
+          id: "club",
+          name: "Club",
+          entityType: "items",
+          summary: "Club",
+          description: "Club weapon",
+          portraitUrl: null,
+          iconUrl: null,
+          effects: [],
+          data: { category: "weapon", weaponType: "melee", damage: "1d6", crit: "x2" }
+        }],
+        skills: [],
+        rules: [{
+          id: "base-ac",
+          name: "Base AC",
+          entityType: "rules",
+          summary: "Base AC",
+          description: "Base AC",
+          portraitUrl: null,
+          iconUrl: null,
+          effects: [{ kind: "set", targetPath: "stats.ac", value: { const: 10 } }]
+        }]
+      },
+      flow: {
+        steps: [
+          { id: "name", kind: "metadata", label: "Name", source: { type: "manual" } },
+          { id: "abilities", kind: "abilities", label: "Ability Scores", source: { type: "manual" } },
+          { id: "race", kind: "race", label: "Race", source: { type: "entityType", entityType: "races", limit: 1 } },
+          { id: "class", kind: "class", label: "Class", source: { type: "entityType", entityType: "classes", limit: 1 } }
+        ]
+      },
+      patches: [],
+      packPath: "size-pack"
+    };
+    const localContext = {
+      enabledPackIds: ["size-pack"],
+      resolvedData: resolveLoadedPacks([makePack("base", 1), sizePack], ["size-pack"])
+    };
+
+    let state = applyChoice(initialState, "name", "Tiny");
+    state = applyChoice(state, "abilities", { str: 10, dex: 10, con: 10, int: 10, wis: 10, cha: 10 });
+    state = applyChoice(state, "race", "tinyling");
+    state = applyChoice(state, "class", "fighter");
+    state = { ...state, selections: { ...state.selections, equipment: ["club"] } };
+
+    const sheet = finalizeCharacter(state, localContext);
+
+    expect(sheet.sheetViewModel.combat.attacks).toEqual([
+      expect.objectContaining({
+        itemId: "club",
+        attackBonusBreakdown: {
+          total: 2,
+          bab: 1,
+          ability: 0,
+          size: 1,
+          misc: 0
+        }
+      })
+    ]);
+  });
 });
 
 describe("engine determinism", () => {

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -1620,7 +1620,8 @@ export function finalizeCharacter(state: CharacterState, context: EngineContext)
     .map(([skillId, skill]) => {
       const misc = skill.miscBonus;
       const skillEntity = entityBuckets.skills?.[skillId];
-      const acp = skillIsAffectedByArmorCheckPenalty(skillEntity) ? acpPenalty : 0;
+      const acpApplied = skillIsAffectedByArmorCheckPenalty(skillEntity);
+      const acp = acpApplied ? acpPenalty : 0;
       return {
         id: skillId,
         name: skill.name,
@@ -1629,7 +1630,7 @@ export function finalizeCharacter(state: CharacterState, context: EngineContext)
         racial: skill.racialBonus,
         misc,
         acp,
-        acpApplied: skillIsAffectedByArmorCheckPenalty(skillEntity),
+        acpApplied,
         total: skill.total + acp
       };
     });
@@ -1655,7 +1656,7 @@ export function finalizeCharacter(state: CharacterState, context: EngineContext)
     }
   };
   const unresolvedRules = collectUnresolvedRules(state, context);
-  const sheetViewModel = buildSheetViewModel({ phase1, phase2, skills });
+  const sheetViewModel = buildSheetViewModel({ phase1, phase2, skills, decisions });
 
   return {
     metadata: { name: sheet.metadata.name },
@@ -1673,7 +1674,7 @@ export function finalizeCharacter(state: CharacterState, context: EngineContext)
   };
 }
 
-export function buildSheetViewModel(characterSheet: Pick<CharacterSheet, "phase1" | "phase2" | "skills">): SheetViewModel {
+export function buildSheetViewModel(characterSheet: Pick<CharacterSheet, "phase1" | "phase2" | "skills" | "decisions">): SheetViewModel {
   const ac = characterSheet.phase1.combat.ac;
   const acBase =
     ac.total
@@ -1687,10 +1688,10 @@ export function buildSheetViewModel(characterSheet: Pick<CharacterSheet, "phase1
   const bab = characterSheet.phase1.combat.grapple.bab;
   const meleeAbility = characterSheet.phase1.combat.grapple.str;
   const rangedAbility = characterSheet.phase1.combat.initiative.dex;
-  const sizeModifier = ac.breakdown.size;
+  const attackSizeModifier = characterSheet.decisions.sizeModifiers.attack;
   const attacks = [
     ...characterSheet.phase1.combat.attacks.melee.map((attack) => {
-      const misc = attack.attackBonus - bab - meleeAbility - sizeModifier;
+      const misc = attack.attackBonus - bab - meleeAbility - attackSizeModifier;
       const damageLine = /[+-]\d+$/.test(attack.damage)
         ? attack.damage
         : formatDamageWithModifier(attack.damage, meleeAbility);
@@ -1701,14 +1702,14 @@ export function buildSheetViewModel(characterSheet: Pick<CharacterSheet, "phase1
           total: attack.attackBonus,
           bab,
           ability: meleeAbility,
-          size: sizeModifier,
+          size: attackSizeModifier,
           misc
         },
         damageLine
       };
     }),
     ...characterSheet.phase1.combat.attacks.ranged.map((attack) => {
-      const misc = attack.attackBonus - bab - rangedAbility - sizeModifier;
+      const misc = attack.attackBonus - bab - rangedAbility - attackSizeModifier;
       return {
         ...attack,
         category: "ranged" as const,
@@ -1716,7 +1717,7 @@ export function buildSheetViewModel(characterSheet: Pick<CharacterSheet, "phase1
           total: attack.attackBonus,
           bab,
           ability: rangedAbility,
-          size: sizeModifier,
+          size: attackSizeModifier,
           misc
         },
         damageLine: attack.damage


### PR DESCRIPTION
Issue #81: Implement sheetViewModel output in engine

## Summary
- Add SheetViewModel interface with combat (AC breakdown, components, touch, flat-footed, attacks) and skills
- Add buildSheetViewModel() function
- Include sheetViewModel in finalizeCharacter() output
- Update React App.tsx to render from sheetViewModel instead of recomputing
- Add engine test for sheetViewModel contract

## Acceptance
UI renders from sheetViewModel without recomputing logic in React.

Closes #81