### PR TITLE
docs(engineering): record merged E2E progress for #93/#94

### DIFF
--- a/docs/engineering/BACKLOG_TRIAGE.md
+++ b/docs/engineering/BACKLOG_TRIAGE.md
@@ -1,6 +1,6 @@
 # Backlog Triage
 
-Last updated: 2026-03-03
+Last updated: 2026-03-05
 
 This document records the recommended execution order for currently open GitHub issues, plus the intended duplicate and umbrella relationships. It exists to keep repo planning in sync with the actual codebase rather than a stale backlog snapshot.
 
@@ -20,8 +20,8 @@ This document records the recommended execution order for currently open GitHub 
    - `#104` expose skill budget breakdown
 3. Regression coverage for the same slice:
    - `#96` contract tests for skill-budget invariants
-   - `#94` E2E regression for the skills step
-   - `#93` E2E regression for the abilities step
+   - `#94` E2E regression for the skills step (completed via PR #121 on 2026-03-05)
+   - `#93` E2E regression for the abilities step (completed via PR #120 on 2026-03-05)
 4. `#72` Stabilize item schema for Phase-1 sheet output
 5. `#70` minimal SRD 3.5 skill list completion
 6. `#77` feat legality and fighter bonus-feat handling

--- a/docs/engineering/WORK_PLAN.md
+++ b/docs/engineering/WORK_PLAN.md
@@ -32,7 +32,7 @@ This living document tracks the engineering tasks required to implement the DnDC
    - [x] Add unit tests for engine (engine package).
    - [x] Add contract tests for the minimal SRD pack.
    - [x] Add wizard integration coverage (Vitest RTL) and initial visual regression coverage (Playwright).
-   - [ ] Add deeper E2E coverage for critical abilities and skills regressions.
+   - [x] Add deeper E2E coverage for critical abilities and skills regressions.
 
 ### Future Phases (Beyond MVP)
 
@@ -72,6 +72,7 @@ This living document tracks the engineering tasks required to implement the DnDC
 - Added review/export surfaces backed by `sheetViewModel`, including attack breakdowns, skill breakdowns, provenance display, and JSON export.
 - Added pack contract fixtures for the minimal SRD pack, wired `npm run check:contract-fixtures` and `npm run contracts` into CI, and enforced ASCII/bidi safety for contract JSON.
 - Added initial Playwright visual regression coverage alongside the existing Vitest wizard-flow integration tests.
+- Merged PR #120 and PR #121 to add dedicated Playwright regression suites for the abilities and skills steps, including EN/ZH coverage and level-1 rank-cap assertions for skills.
 - Added race-level `deferredMechanics` tracking in schema and `races.json` so PHB-linked but not-yet-implemented race rules are indexed for fast follow-up when dependent systems land.
 - Recorded the approved deferred-mechanics normalization direction in docs so backlog metadata can migrate from engine-oriented path hints to stable concept IDs and capability IDs in a later implementation phase.
 - Implemented deferred-mechanics normalization across schema validation, tests, docs, and SRD race/class/feat pack data.


### PR DESCRIPTION
## Summary\n- update engineering progress docs after merged PR #120 and PR #121\n- mark deeper abilities/skills E2E regression coverage as completed\n- annotate backlog triage entries for #93 and #94 as completed on 2026-03-05\n\n## Context\nPR #121 was already merged, so these doc updates are being landed via a docs-only follow-up PR to keep main progress tracking accurate.\n\n## Verification\n- docs-only changes\n- no runtime code changes