### PR TITLE
fix(skills): keep Open Lock and Use Rope as non-ACP

### DIFF
--- a/packs/srd-35e-minimal/authenticity.lock.json
+++ b/packs/srd-35e-minimal/authenticity.lock.json
@@ -24,7 +24,7 @@
     },
     {
       "path": "entities/skills.json",
-      "sha256": "9c12d683ab5e4d4acb4aac22976aee675642d9bbd3dd9f3947d047ecb30b55fd"
+      "sha256": "fa2d2485e892c813d4a2aa86a6bbb6d0578657dcbfc755248c47fccfc0c2359d"
     },
     {
       "path": "entities/items.json",

--- a/packs/srd-35e-minimal/contracts/human-fighter-1.json
+++ b/packs/srd-35e-minimal/contracts/human-fighter-1.json
@@ -485,8 +485,8 @@
             "ability": 1,
             "racial": 0,
             "misc": 0,
-            "acp": 0,
-            "total": 5
+            "acp": -7,
+            "total": -2
           },
           {
             "id": "search",
@@ -510,7 +510,7 @@
           },
           {
             "id": "sleight-of-hand",
-            "name": "Sleight Of Hand",
+            "name": "Sleight of Hand",
             "ranks": 0,
             "ability": 1,
             "racial": 0,

--- a/packs/srd-35e-minimal/entities/skills.json
+++ b/packs/srd-35e-minimal/entities/skills.json
@@ -434,7 +434,7 @@
     "entityType": "skills",
     "data": {
       "ability": "dex",
-      "armorCheckPenaltyApplies": false
+      "armorCheckPenaltyApplies": true
     },
     "summary": "Ride (skill) option.",
     "description": "Detailed reference entry for Ride in the skills dataset.",
@@ -469,14 +469,14 @@
   },
   {
     "id": "sleight-of-hand",
-    "name": "Sleight Of Hand",
+    "name": "Sleight of Hand",
     "entityType": "skills",
     "data": {
       "ability": "dex",
       "armorCheckPenaltyApplies": true
     },
-    "summary": "Sleight Of Hand (skill) option.",
-    "description": "Detailed reference entry for Sleight Of Hand in the skills dataset.",
+    "summary": "Sleight of Hand (skill) option.",
+    "description": "Detailed reference entry for Sleight of Hand in the skills dataset.",
     "portraitUrl": null,
     "iconUrl": null
   },


### PR DESCRIPTION
## Summary
- Keep open-lock as non-ACP (rmorCheckPenaltyApplies: false)
- Keep use-rope as non-ACP (rmorCheckPenaltyApplies: false)
- Keep ide ACP behavior unchanged
- Keep naming fix Sleight of Hand
- Sync contract fixture and authenticity lock

## Validation
- 
pm --workspace @dcb/contracts run test
- 
pm --workspace @dcb/datapack run test

Related: #132