### PR TITLE
[P0] Add schema-driven page composition design and rollout plan

### DIFF
--- a/docs/plans/2026-03-10-schema-driven-page-composition-design.md
+++ b/docs/plans/2026-03-10-schema-driven-page-composition-design.md
@@ -28,10 +28,13 @@ That creates two kinds of drift:
 
 1. Keep `flow` focused on wizard sequencing, not page layout details.
 2. Give every page its own schema file.
-3. Compose pages from typed, registered UI blocks rather than arbitrary renderer ids.
+3. Represent each page as a recursive component tree rather than a flat block list.
+4. Compose pages from typed, registered UI components rather than arbitrary renderer ids.
 4. Keep v1 declarative only:
    - fixed data-path bindings
    - static props
+   - recursive `children`
+   - explicit `slot` placement
    - no expressions
    - no embedded filtering / sorting language
    - no custom renderer escape hatch
@@ -92,30 +95,51 @@ This keeps page schemas:
 Each page schema declares:
 
 - page identity
-- optional title / description keys
-- ordered block list
-- static block props
+- a recursive root node
+- static node props
 - declarative data bindings by path
+- optional `children`
+- optional `slot` routing into a parent component
 
 Example direction:
 
 ```json
 {
   "id": "character.review",
-  "titleKey": "REVIEW",
-  "blocks": [
-    { "id": "hero", "type": "reviewHero", "bindings": { "name": "spec.meta.name" } },
-    { "id": "summary", "type": "statCards", "source": "review.summaryCards" },
-    { "id": "skills", "type": "skillsBreakdown", "source": "review.skills" }
-  ]
+  "root": {
+    "id": "review-root",
+    "componentId": "layout.twoColumnReview",
+    "children": [
+      {
+        "id": "hero",
+        "componentId": "reviewHero",
+        "slot": "header",
+        "dataSource": "page.review.hero"
+      },
+      {
+        "id": "summary",
+        "componentId": "statCards",
+        "slot": "main",
+        "dataSource": "page.review.summaryCards"
+      },
+      {
+        "id": "skills",
+        "componentId": "skillsBreakdown",
+        "slot": "main",
+        "dataSource": "page.review.skills"
+      }
+    ]
+  }
 }
 ```
 
 ### Layer 3: Page Composer + Component Registry
 
-The web app owns a typed registry of allowed block components.
+The web app owns a typed registry of allowed components.
 
-Representative block types:
+Layouts are not a separate schema layer. A layout is just another registered component that accepts children in named slots.
+
+Representative component ids:
 
 - `textField`
 - `choiceGroup`
@@ -128,12 +152,14 @@ Representative block types:
 - `combatBreakdown`
 - `skillsBreakdown`
 - `provenancePanel`
+- `layout.singleColumn`
+- `layout.twoColumnReview`
 
-The registry is explicit and closed. Unknown block types fail validation rather than silently rendering nothing.
+The registry is explicit and closed. Unknown component ids fail validation rather than silently rendering nothing.
 
 `PageComposer` becomes the only runtime that turns:
 
-`pageSchemaId -> page schema -> registered block tree -> rendered page`
+`pageSchemaId -> page schema root node -> registered component tree -> rendered page`
 
 ## Binding model (v1)
 
@@ -155,6 +181,34 @@ Disallowed in v1:
 
 This keeps the page schemas stable and reviewable. Any nontrivial transformation belongs in a typed selector/adapter layer inside the web app.
 
+## Tree model and slot routing
+
+Each page schema is a recursive node tree.
+
+Each node may contain:
+
+- `id`
+- `componentId`
+- `props`
+- `dataSource`
+- `children`
+- `slot`
+
+Rules:
+
+- `componentId` must exist in the registry
+- `dataSource` is optional and path-only
+- `children` is optional and static in v1
+- `slot` is optional and only meaningful when the parent component exposes named insertion regions
+
+This gives us one uniform composition model:
+
+- layout components are just nodes
+- domain blocks are just nodes
+- leaf display components are just nodes
+
+We do not need separate schema systems for layout, sections, and leaves.
+
 ## Data shaping rule
 
 JSON does not shape raw engine output directly.
@@ -175,7 +229,7 @@ This avoids turning page JSON into a query language.
 
 ## Component abstraction rule
 
-We should not over-normalize blocks into layout primitives only.
+We should not over-normalize components into layout primitives only.
 
 Keep semantically meaningful domain blocks when they are stable, for example:
 
@@ -183,8 +237,9 @@ Keep semantically meaningful domain blocks when they are stable, for example:
 - `abilityBreakdown`
 - `combatBreakdown`
 - `skillsBreakdown`
+- `layout.twoColumnReview`
 
-Those blocks are better than forcing every page author to reconstruct them from low-level primitives. Primitive blocks still exist, but they do not replace every domain block.
+Those components are better than forcing every page author to reconstruct them from low-level primitives. Primitive components still exist, but they do not replace every domain block.
 
 ## Current hardcoded surfaces to migrate
 
@@ -238,20 +293,25 @@ Expected migration sequence:
 2. Overly powerful schema language:
    expression support too early would move logic into config and make testing harder.
 
-3. Wrong block granularity:
-   if blocks are too low-level, schemas become noisy and fragile.
-   if blocks are too high-level, the schema adds little value.
+3. Wrong component granularity:
+   if components are too low-level, schemas become noisy and fragile.
+   if components are too high-level, the schema adds little value.
 
 4. Flow/page ownership drift:
    if page layout fields continue to accumulate inside flow step objects, the separation collapses again.
+
+5. Slot misuse:
+   if slot naming is inconsistent or under-specified, layouts become hard to reason about and schemas become trial-and-error.
 
 ## Guardrails
 
 - Keep flow and page schema responsibilities separate.
 - Validate page schemas in a typed schema package before runtime.
 - Keep bindings path-only in v1.
+- Keep children static and recursive in v1.
+- Keep slot names component-defined and validated.
 - Use typed selectors/adapters for shaping.
-- Fail closed on unknown block types and invalid bindings.
+- Fail closed on unknown component ids and invalid bindings.
 - Migrate page-by-page rather than doing a big-bang rewrite.
 
 ## Duplicate issue audit

--- a/docs/plans/2026-03-10-schema-driven-page-composition-implementation.md
+++ b/docs/plans/2026-03-10-schema-driven-page-composition-implementation.md
@@ -4,7 +4,7 @@
 
 **Goal:** Introduce schema-driven page composition so wizard pages are assembled from pack-owned JSON page schemas and stable registered UI components instead of hardcoded `App.tsx` branches.
 
-**Architecture:** Keep `flow` responsible for wizard sequencing and `pageSchemaId` references. Add standalone page schema files under pack-owned UI config, a typed page-schema contract and loader, a closed component registry, and a `PageComposer` runtime. Migrate existing page branches to schema-driven composition incrementally, starting with simpler surfaces and preserving the engine/UI boundary from `#162`.
+**Architecture:** Keep `flow` responsible for wizard sequencing and `pageSchemaId` references. Add standalone page schema files under pack-owned UI config, a typed recursive page-schema contract, a closed component registry, and a `PageComposer` runtime that walks a recursive node tree with optional named `slot` placement. Migrate existing page branches to schema-driven composition incrementally, starting with simpler surfaces and preserving the engine/UI boundary from `#162`.
 
 **Tech Stack:** React, TypeScript, npm workspaces, pack JSON files, schema validation package, Vitest, Playwright, GitHub issues.
 
@@ -56,23 +56,25 @@ Do not store page layout blocks inline inside flow step objects.
 
 Add a `PageSchema` contract that validates:
 - page id
-- title/description keys where needed
-- ordered block list
-- block ids
-- block type enum / discriminated union
+- recursive root node
+- node ids
+- component id enum / discriminated union
 - static props
 - path-only bindings
+- optional `children`
+- optional `slot`
 
 Expected runtime behavior:
 - invalid page schema fails load/validation
-- unknown block type fails validation
+- unknown component id fails validation
 
 **Step 3: Add pack-local fixture coverage**
 
 Add tests proving:
 - valid sample page schema parses
-- unknown block type is rejected
+- unknown component id is rejected
 - forbidden expression-like binding strings are rejected if they violate the path-only rule
+- invalid slot usage is rejected where the schema can validate it
 
 ### Task 3: Extend flow to reference page schemas without swallowing layout config
 
@@ -92,7 +94,7 @@ Keep existing flow responsibilities intact:
 - gating
 - step ids
 
-Do not add nested block trees to the flow step object.
+Do not add recursive page trees to the flow step object.
 
 **Step 2: Decide how legacy step config coexists during migration**
 
@@ -150,15 +152,17 @@ This adapter is where shaping belongs. Do not move shaping logic into JSON.
 
 **Step 1: Introduce a closed registry**
 
-Implement a typed registry mapping block `type` to React component.
+Implement a typed registry mapping `componentId` to React component, including layout components.
 
 Runtime rule:
-- unknown block types are validation/runtime errors, not silent no-ops
+- unknown component ids are validation/runtime errors, not silent no-ops
 
 **Step 2: Implement minimal composer behavior**
 
 Support:
-- ordered block rendering
+- recursive node rendering
+- static child lists
+- optional slot routing into parent components
 - static props
 - path-bound values from prepared page context
 - consistent wrapper/layout behavior
@@ -166,10 +170,11 @@ Support:
 **Step 3: Add targeted tests**
 
 Cover:
-- block dispatch by type
-- missing block handling
+- node dispatch by component id
+- missing component handling
 - binding resolution for valid path references
-- deterministic rendering order
+- deterministic child rendering order
+- slot placement behavior
 
 ### Task 6: Extract stable block components from the current App.tsx branches
 
@@ -178,9 +183,9 @@ Cover:
 - Modify: `apps/web/src/App.tsx`
 - Test: `apps/web/src/App.test.tsx`
 
-**Step 1: Extract semantically meaningful blocks first**
+**Step 1: Extract semantically meaningful components first**
 
-Candidate first-class blocks:
+Candidate first-class components:
 - `ReviewHeroBlock`
 - `StatCardsBlock`
 - `AbilityBreakdownBlock`
@@ -189,10 +194,11 @@ Candidate first-class blocks:
 - `MetadataNameFieldBlock`
 - `AbilityAllocatorBlock`
 - `SkillsAllocatorBlock`
+- `TwoColumnReviewLayout`
 
 **Step 2: Preserve domain meaning**
 
-Do not flatten everything into low-level primitives unless the block is genuinely reusable.
+Do not flatten everything into low-level primitives unless the component is genuinely reusable.
 
 **Step 3: Keep behavior unchanged**
 
@@ -209,7 +215,7 @@ Extraction should not redesign the UI. Existing tests should remain the regressi
 
 Move the current metadata page structure into a page schema and render it through `PageComposer`.
 
-**Step 2: Migrate low-risk display-only review blocks**
+**Step 2: Migrate low-risk display-only review components**
 
 Good initial candidates:
 - review hero
@@ -219,7 +225,7 @@ Good initial candidates:
 
 **Step 3: Verify no behavior drift**
 
-Run focused tests after each migrated page/block.
+Run focused tests after each migrated page/component.
 
 ### Task 8: Migrate complex interactive pages in controlled slices
 


### PR DESCRIPTION
## Summary
- add the architecture design doc for schema-driven page composition (`#181`)
- add the rollout/implementation plan doc for the architecture (`#182`)
- record the initial child issue breakdown (`#183`-`#188`)

## Context
This PR does not implement the runtime. It captures the approved architecture and execution plan for moving from hardcoded `App.tsx` page rendering to config-defined pages composed from registered UI blocks.

## Related Issues
- #181
- #182
- #183
- #184
- #185
- #186
- #187
- #188
- related backlog context: #88, #151, #162

## Test Plan
- docs-only change; no code or runtime behavior changed
