### PR TITLE
feat(ui): migrate review page to schema-driven composition

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -218,6 +218,17 @@ describe('wizard e2e-ish happy path', () => {
     expect(screen.getByLabelText(new RegExp(`${en.NAME_LABEL}|${zh.NAME_LABEL}`, 'i'))).toBeTruthy();
   });
 
+  it('renders the review page through a page schema when the flow references one', async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await reachReviewStep(user);
+
+    expect(screen.getByRole('heading', { name: reviewPattern })).toBeTruthy();
+    const reviewPage = document.querySelector('[data-page-schema-id="character.review"]');
+    expect(reviewPage).toBeTruthy();
+  });
+
   it('lets user complete flow and see final stats', async () => {
     const user = userEvent.setup();
     render(<App />);

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -26,7 +26,10 @@ import { resolveSpecializedSkillLabel } from "./localization";
 import { AbilityMethodSelector } from "./components/AbilityMethodSelector";
 import { PointBuyPanel } from "./components/PointBuyPanel";
 import { characterSpecFromState } from "./characterSpecFromState";
-import { PageComposer } from "./pageComposer/PageComposer";
+import {
+  PageComposer,
+  type ReviewSheetData,
+} from "./pageComposer/PageComposer";
 
 const embeddedPacks = [loadMinimalPack()];
 type Role = "dm" | "player" | null;
@@ -644,6 +647,292 @@ export function App() {
     if (currentStep.pageSchemaId) {
       const pageSchema = context.resolvedData.pageSchemas[currentStep.pageSchemaId];
       if (pageSchema) {
+        if (currentStep.kind === "review") {
+          const reviewCombat = combatData;
+          const abilityOrder = ["str", "dex", "con", "int", "wis", "cha"] as const;
+          const statOrder = [
+            "hp",
+            "ac",
+            "initiative",
+            "bab",
+            "fort",
+            "ref",
+            "will",
+          ] as const;
+          const statLabels: Record<(typeof statOrder)[number], string> = {
+            hp: t.REVIEW_HP_LABEL,
+            ac: t.REVIEW_AC_LABEL,
+            initiative: t.REVIEW_INITIATIVE_LABEL,
+            bab: t.REVIEW_BAB_LABEL,
+            fort: t.REVIEW_FORT_LABEL,
+            ref: t.REVIEW_REF_LABEL,
+            will: t.REVIEW_WILL_LABEL,
+          };
+          const statBaseDefaults: Record<(typeof statOrder)[number], number> = {
+            hp: DEFAULT_STATS.hp,
+            ac: DEFAULT_STATS.ac,
+            initiative: DEFAULT_STATS.initiative,
+            bab: DEFAULT_STATS.bab,
+            fort: DEFAULT_STATS.fort,
+            ref: DEFAULT_STATS.ref,
+            will: DEFAULT_STATS.will,
+          };
+          const formatSigned = (value: number) =>
+            `${value >= 0 ? "+" : ""}${value}`;
+          const formatSkillValue = (value: number) =>
+            `${Number.isInteger(value) ? value : value.toFixed(1)}`;
+          const formatSourceLabel = (packId: string, entityId: string) =>
+            sourceNameByEntityId.get(`${packId}:${entityId}`) ?? t.REVIEW_UNRESOLVED_LABEL;
+          const selectedRaceId = String(state.selections.race ?? "");
+          const selectedClassId = spec.class?.classId ?? String(state.selections.class ?? "");
+          const selectedRaceName = selectedRaceId
+            ? localizeEntityText(
+                "races",
+                selectedRaceId,
+                "name",
+                selectedRaceEntity?.name ?? t.REVIEW_UNRESOLVED_LABEL,
+              )
+            : t.REVIEW_UNRESOLVED_LABEL;
+          const selectedClassName = selectedClassId
+            ? localizeEntityText(
+                "classes",
+                selectedClassId,
+                "name",
+                selectedClassEntity?.name ?? t.REVIEW_UNRESOLVED_LABEL,
+              )
+            : t.REVIEW_UNRESOLVED_LABEL;
+          const finalStatValues = {
+            hp: reviewData.hp.total,
+            ac: reviewCombat.ac.total,
+            initiative: reviewData.initiative.total,
+            bab: reviewData.bab,
+            fort: reviewData.saves.fort.total,
+            ref: reviewData.saves.ref.total,
+            will: reviewData.saves.will.total,
+          } as const;
+          const racialTraits = Array.isArray(
+            getEntityDataRecord(selectedRaceEntity).racialTraits,
+          )
+            ? (getEntityDataRecord(selectedRaceEntity).racialTraits as Array<
+                Record<string, unknown>
+              >)
+            : [];
+          const reviewSkills = computeResult.sheetViewModel.data.skills
+            .filter((skill) => skill.ranks > 0 || skill.racialBonus !== 0)
+            .sort((a, b) => {
+              const left = localizeEntityText("skills", a.id, "name", a.name);
+              const right = localizeEntityText("skills", b.id, "name", b.name);
+              return b.total - a.total || left.localeCompare(right);
+            });
+          const enabledPackDetails = enabledPackIds.map((packId) => ({
+            packId,
+            version: packVersionById.get(packId) ?? t.REVIEW_UNKNOWN_VERSION,
+          }));
+          const skillBudget = reviewData.skillBudget;
+          const reviewSheetData: ReviewSheetData = {
+            t,
+            characterName: spec.meta.name || t.UNNAMED_CHARACTER,
+            selectedRaceName,
+            selectedClassName,
+            identityRows: [
+              { label: t.REVIEW_LEVEL_LABEL, value: reviewData.identity.level },
+              { label: t.REVIEW_XP_LABEL, value: reviewData.identity.xp },
+              { label: t.REVIEW_SIZE_LABEL, value: reviewData.identity.size },
+              { label: t.REVIEW_SPEED_BASE_LABEL, value: reviewData.identity.speed.base },
+              { label: t.REVIEW_SPEED_ADJUSTED_LABEL, value: reviewData.identity.speed.adjusted },
+            ],
+            statCards: [
+              { label: t.REVIEW_AC_LABEL, value: reviewCombat.ac.total },
+              { label: t.REVIEW_AC_TOUCH_LABEL, value: reviewCombat.ac.touch },
+              { label: t.REVIEW_AC_FLAT_FOOTED_LABEL, value: reviewCombat.ac.flatFooted },
+              { label: t.REVIEW_HP_LABEL, value: reviewData.hp.total },
+              { label: t.REVIEW_INITIATIVE_LABEL, value: reviewData.initiative.total },
+              { label: t.REVIEW_GRAPPLE_LABEL, value: reviewData.grapple.total },
+            ],
+            saveHpRows: [
+              {
+                label: t.REVIEW_FORT_LABEL,
+                base: reviewData.saves.fort.base,
+                ability: reviewData.saves.fort.ability,
+                adjustments: reviewData.saves.fort.misc,
+                final: reviewData.saves.fort.total,
+              },
+              {
+                label: t.REVIEW_REF_LABEL,
+                base: reviewData.saves.ref.base,
+                ability: reviewData.saves.ref.ability,
+                adjustments: reviewData.saves.ref.misc,
+                final: reviewData.saves.ref.total,
+              },
+              {
+                label: t.REVIEW_WILL_LABEL,
+                base: reviewData.saves.will.base,
+                ability: reviewData.saves.will.ability,
+                adjustments: reviewData.saves.will.misc,
+                final: reviewData.saves.will.total,
+              },
+              {
+                label: t.REVIEW_HP_LABEL,
+                base: reviewData.hp.breakdown.hitDie,
+                ability: reviewData.hp.breakdown.con,
+                adjustments: reviewData.hp.breakdown.misc,
+                final: reviewData.hp.total,
+              },
+            ],
+            attackRows: reviewCombat.attacks.map((attack) => ({
+              id: `${attack.category}-${attack.itemId}`,
+              typeLabel:
+                attack.category === "melee"
+                  ? t.REVIEW_ATTACK_MELEE_LABEL
+                  : t.REVIEW_ATTACK_RANGED_LABEL,
+              name: attack.name,
+              attackBonus: formatSigned(attack.attackBonus),
+              damage: attack.damageLine,
+              crit: attack.crit,
+              range: attack.category === "ranged" ? attack.range ?? "-" : "-",
+            })),
+            featSummary: selectedFeats.map((featId) => {
+              const feat = context.resolvedData.entities.feats?.[featId];
+              return {
+                id: featId,
+                name: feat?.name ?? featId,
+                description: feat?.summary ?? feat?.description ?? featId,
+              };
+            }),
+            traitSummary: racialTraits.map((trait, index) => ({
+              id: `${String(trait.name ?? "")}-${index}`,
+              name: String(trait.name ?? ""),
+              description: String(trait.description ?? "").trim(),
+            })),
+            abilityRows: abilityOrder.map((ability) => {
+              const baseScore = Number(state.abilities[ability] ?? 10);
+              const targetPath = `abilities.${ability}.score`;
+              const records = provenanceByTargetPath.get(targetPath) ?? [];
+              const finalScore = reviewData.abilities[ability]?.score ?? baseScore;
+              const finalMod = reviewData.abilities[ability]?.mod ?? 0;
+              return {
+                id: ability,
+                label: localizeAbilityLabel(ability),
+                base: baseScore,
+                adjustments: records.map((record) => ({
+                  value:
+                    record.delta !== undefined
+                      ? formatSigned(record.delta)
+                      : `= ${record.setValue ?? 0}`,
+                  source: formatSourceLabel(record.source.packId, record.source.entityId),
+                })),
+                final: finalScore,
+                mod: formatSigned(finalMod),
+              };
+            }),
+            combatRows: statOrder.map((statKey) => {
+              const targetPath = `stats.${statKey}`;
+              const records = provenanceByTargetPath.get(targetPath) ?? [];
+              const firstSetIndex = records.findIndex(
+                (record) => record.setValue !== undefined,
+              );
+              const baseValue =
+                firstSetIndex >= 0
+                  ? Number(
+                      records[firstSetIndex]?.setValue ??
+                        statBaseDefaults[statKey],
+                    )
+                  : statBaseDefaults[statKey];
+              const adjustmentRecords = records.filter(
+                (_, index) => index !== firstSetIndex,
+              );
+              return {
+                id: statKey,
+                label: statLabels[statKey],
+                base: baseValue,
+                adjustments: adjustmentRecords.map((record) => ({
+                  value:
+                    record.delta !== undefined
+                      ? formatSigned(record.delta)
+                      : `= ${record.setValue ?? 0}`,
+                  source: formatSourceLabel(record.source.packId, record.source.entityId),
+                })),
+                final: String(finalStatValues[statKey]),
+              };
+            }),
+            skillsSummary: {
+              spent: skillBudget.spent,
+              total: skillBudget.total,
+              remaining: skillBudget.remaining,
+            },
+            skillsRows: reviewSkills.map((skill) => ({
+              id: skill.id,
+              name: localizeEntityText("skills", skill.id, "name", skill.name),
+              ranks: formatSkillValue(skill.ranks),
+              ability: `${formatSigned(skill.abilityMod)} (${localizeAbilityLabel(skill.abilityKey)})`,
+              racial: formatSigned(skill.racialBonus),
+              misc: formatSigned(skill.misc),
+              acp: formatSigned(skill.acp),
+              total: formatSkillValue(skill.total),
+              pointCost: `${formatSkillValue(skill.costSpent)} (${skill.costPerRank}${t.REVIEW_PER_RANK_UNIT})`,
+            })),
+            equipmentLoad: {
+              selectedItems:
+                reviewData.equipmentLoad.selectedItems.length > 0
+                  ? reviewData.equipmentLoad.selectedItems
+                      .map((itemId) =>
+                        localizeEntityText("items", itemId, "name", itemId),
+                      )
+                      .join(", ")
+                  : "-",
+              totalWeight: reviewData.equipmentLoad.totalWeight,
+              loadCategory: localizeLoadCategory(reviewData.equipmentLoad.loadCategory),
+              speedImpact: formatSpeedImpact(
+                reviewData.speed.adjusted,
+                reviewData.equipmentLoad.reducesSpeed,
+              ),
+            },
+            movementDetail: {
+              base: reviewData.speed.base,
+              adjusted: reviewData.speed.adjusted,
+              notes: formatMovementNotes(
+                reviewData.movement.reducedByArmorOrLoad,
+              ).join("; "),
+            },
+            rulesDecisions: {
+              favoredClass: reviewData.rulesDecisions.favoredClass
+                ? reviewData.rulesDecisions.favoredClass === "any"
+                  ? t.REVIEW_FAVORED_CLASS_ANY
+                  : localizeEntityText(
+                      "classes",
+                      reviewData.rulesDecisions.favoredClass,
+                      "name",
+                      reviewData.rulesDecisions.favoredClass,
+                    )
+                : t.REVIEW_UNRESOLVED_LABEL,
+              ignoresMulticlassXpPenalty: reviewData.rulesDecisions.ignoresMulticlassXpPenalty
+                ? t.REVIEW_YES
+                : t.REVIEW_NO,
+              featSelectionLimit: reviewData.rulesDecisions.featSelectionLimit,
+            },
+            packInfo: {
+              selectedEdition: selectedEdition.label || selectedEdition.id || "-",
+              enabledPacks: enabledPackDetails,
+              fingerprint: context.resolvedData.fingerprint,
+            },
+            showProvenance: showProv,
+            provenanceJson: JSON.stringify(computeResult.provenance ?? [], null, 2),
+            onExportJson: exportJson,
+            onToggleProvenance: () => setShowProv((s) => !s),
+          };
+
+          return (
+            <PageComposer
+              schema={pageSchema}
+              dataRoot={{
+                page: {
+                  reviewSheet: reviewSheetData,
+                },
+              }}
+            />
+          );
+        }
+
         if (currentStep.kind === "metadata") {
           return (
             <PageComposer

--- a/apps/web/src/loadMinimalPack.test.ts
+++ b/apps/web/src/loadMinimalPack.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { loadMinimalPack } from "./loadMinimalPack";
 
 describe("loadMinimalPack", () => {
-  it("includes pack-owned page schemas for migrated race, class, and metadata steps", () => {
+  it("includes pack-owned page schemas for migrated race, class, metadata, and review steps", () => {
     const pack = loadMinimalPack();
     const pageSchemas = pack.pageSchemas;
 
@@ -15,6 +15,9 @@ describe("loadMinimalPack", () => {
     expect(pack.flow.steps.find((step) => step.id === "name")?.pageSchemaId).toBe(
       "character.name",
     );
+    expect(pack.flow.steps.find((step) => step.id === "review")?.pageSchemaId).toBe(
+      "character.review",
+    );
     expect(pageSchemas?.["character.race"]?.root.componentId).toBe(
       "layout.singleColumn",
     );
@@ -26,5 +29,9 @@ describe("loadMinimalPack", () => {
       pageSchemas?.["character.name"]?.root.children?.[0]
         ?.componentId,
     ).toBe("metadata.nameField");
+    expect(
+      pageSchemas?.["character.review"]?.root.children?.[0]
+        ?.componentId,
+    ).toBe("review.sheet");
   });
 });

--- a/apps/web/src/loadMinimalPack.ts
+++ b/apps/web/src/loadMinimalPack.ts
@@ -13,6 +13,7 @@ import flowJson from '../../../packs/srd-35e-minimal/flows/character-creation.fl
 import racePageJson from '../../../packs/srd-35e-minimal/ui/pages/character.race.page.json';
 import classPageJson from '../../../packs/srd-35e-minimal/ui/pages/character.class.page.json';
 import namePageJson from '../../../packs/srd-35e-minimal/ui/pages/character.name.page.json';
+import reviewPageJson from '../../../packs/srd-35e-minimal/ui/pages/character.review.page.json';
 import enLocaleJson from '../../../packs/srd-35e-minimal/locales/en.json';
 import zhLocaleJson from '../../../packs/srd-35e-minimal/locales/zh.json';
 import type { PackLocale } from '@dcb/datapack';
@@ -33,6 +34,7 @@ export function loadMinimalPack(): LoadedPack {
       [racePageJson.id]: racePageJson as Page,
       [classPageJson.id]: classPageJson as Page,
       [namePageJson.id]: namePageJson as Page,
+      [reviewPageJson.id]: reviewPageJson as Page,
     },
     patches: [],
     locales: {

--- a/apps/web/src/pageComposer/PageComposer.test.tsx
+++ b/apps/web/src/pageComposer/PageComposer.test.tsx
@@ -3,6 +3,9 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { Page } from "@dcb/schema";
 import { PageComposer } from "./PageComposer";
+import uiTextJson from "../uiText.json";
+
+const t = uiTextJson.en;
 
 describe("PageComposer", () => {
   it("renders a slot-based single-select page from schema data", async () => {
@@ -97,5 +100,123 @@ describe("PageComposer", () => {
     await user.type(screen.getByLabelText("Name"), "a");
 
     expect(onChange).toHaveBeenCalledWith("Arica");
+  });
+
+  it("renders a review sheet block from prepared review data", async () => {
+    const user = userEvent.setup();
+    const onExportJson = vi.fn();
+    const onToggleProvenance = vi.fn();
+    const schema: Page = {
+      id: "character.review",
+      root: {
+        id: "review-root",
+        componentId: "layout.singleColumn",
+        children: [
+          {
+            id: "review-sheet",
+            componentId: "review.sheet",
+            slot: "main",
+            dataSource: "page.reviewSheet"
+          }
+        ]
+      }
+    };
+
+    render(
+      <PageComposer
+        schema={schema}
+        dataRoot={{
+          page: {
+            reviewSheet: {
+              t,
+              characterName: "Aric",
+              selectedRaceName: "Human",
+              selectedClassName: "Fighter",
+              identityRows: [{ label: t.REVIEW_LEVEL_LABEL, value: 1 }],
+              statCards: [{ label: t.REVIEW_AC_LABEL, value: 16 }],
+              saveHpRows: [{
+                label: t.REVIEW_FORT_LABEL,
+                base: 2,
+                ability: 2,
+                adjustments: 0,
+                final: 4
+              }],
+              attackRows: [{
+                id: "melee-longsword",
+                typeLabel: t.REVIEW_ATTACK_MELEE_LABEL,
+                name: "Longsword",
+                attackBonus: "+4",
+                damage: "1d8+3",
+                crit: "19-20/x2",
+                range: "-"
+              }],
+              featSummary: [{ id: "power-attack", name: "Power Attack", description: "Trade attack for damage." }],
+              traitSummary: [{ id: "bonus-feat", name: "Bonus Feat", description: "Humans gain one extra feat." }],
+              abilityRows: [{
+                id: "str",
+                label: "STR",
+                base: 16,
+                adjustments: [],
+                final: 16,
+                mod: "+3"
+              }],
+              combatRows: [{
+                id: "bab",
+                label: t.REVIEW_BAB_LABEL,
+                base: 1,
+                adjustments: [],
+                final: "1"
+              }],
+              skillsSummary: { spent: 4, total: 8, remaining: 4 },
+              skillsRows: [{
+                id: "climb",
+                name: "Climb",
+                ranks: "4",
+                ability: "+3 (STR)",
+                racial: "+0",
+                misc: "+0",
+                acp: "-0",
+                total: "7",
+                pointCost: "4 (1/rank)"
+              }],
+              equipmentLoad: {
+                selectedItems: "Chainmail",
+                totalWeight: 40,
+                loadCategory: "Medium",
+                speedImpact: "Reduced to 20"
+              },
+              movementDetail: {
+                base: 30,
+                adjusted: 20,
+                notes: "Reduced by armor or load"
+              },
+              rulesDecisions: {
+                favoredClass: "Any",
+                ignoresMulticlassXpPenalty: "Yes",
+                featSelectionLimit: 2
+              },
+              packInfo: {
+                selectedEdition: "D&D 3.5e SRD",
+                enabledPacks: [{ packId: "srd-35e-minimal", version: "1.0.0" }],
+                fingerprint: "abc123"
+              },
+              showProvenance: false,
+              provenanceJson: "[]",
+              onExportJson,
+              onToggleProvenance
+            }
+          }
+        }}
+      />
+    );
+
+    expect(screen.getByRole("heading", { name: t.REVIEW })).toBeTruthy();
+    expect(screen.getByText("Aric")).toBeTruthy();
+
+    await user.click(screen.getByRole("button", { name: t.EXPORT_JSON }));
+    await user.click(screen.getByRole("button", { name: t.TOGGLE_PROVENANCE }));
+
+    expect(onExportJson).toHaveBeenCalledTimes(1);
+    expect(onToggleProvenance).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/pageComposer/PageComposer.tsx
+++ b/apps/web/src/pageComposer/PageComposer.tsx
@@ -1,5 +1,6 @@
 import type { Page, PageSchemaNode } from "@dcb/schema";
 import type { ReactNode } from "react";
+import type { UIText } from "../uiText";
 
 type SlotChildren = Record<string, ReactNode[]>;
 
@@ -18,6 +19,94 @@ export interface MetadataNameFieldData {
   value: string;
   placeholder?: string;
   onChange: (value: string) => void;
+}
+
+export interface ReviewSheetAdjustmentData {
+  value: string;
+  source: string;
+}
+
+export interface ReviewSheetData {
+  t: UIText;
+  characterName: string;
+  selectedRaceName: string;
+  selectedClassName: string;
+  identityRows: Array<{ label: string; value: string | number }>;
+  statCards: Array<{ label: string; value: string | number }>;
+  saveHpRows: Array<{
+    label: string;
+    base: number;
+    ability: number;
+    adjustments: number;
+    final: number;
+  }>;
+  attackRows: Array<{
+    id: string;
+    typeLabel: string;
+    name: string;
+    attackBonus: string;
+    damage: string;
+    crit: string;
+    range: string;
+  }>;
+  featSummary: Array<{ id: string; name: string; description: string }>;
+  traitSummary: Array<{ id: string; name: string; description: string }>;
+  abilityRows: Array<{
+    id: string;
+    label: string;
+    base: number;
+    adjustments: ReviewSheetAdjustmentData[];
+    final: number;
+    mod: string;
+  }>;
+  combatRows: Array<{
+    id: string;
+    label: string;
+    base: number;
+    adjustments: ReviewSheetAdjustmentData[];
+    final: string | number;
+  }>;
+  skillsSummary: {
+    spent: number;
+    total: number;
+    remaining: number;
+  };
+  skillsRows: Array<{
+    id: string;
+    name: string;
+    ranks: string;
+    ability: string;
+    racial: string;
+    misc: string;
+    acp: string;
+    total: string;
+    pointCost: string;
+  }>;
+  equipmentLoad: {
+    selectedItems: string;
+    totalWeight: number;
+    loadCategory: string;
+    speedImpact: string;
+  };
+  movementDetail: {
+    base: number;
+    adjusted: number;
+    notes: string;
+  };
+  rulesDecisions: {
+    favoredClass: string;
+    ignoresMulticlassXpPenalty: string;
+    featSelectionLimit: number;
+  };
+  packInfo: {
+    selectedEdition: string;
+    enabledPacks: Array<{ packId: string; version: string }>;
+    fingerprint: string;
+  };
+  showProvenance: boolean;
+  provenanceJson: string;
+  onExportJson: () => void;
+  onToggleProvenance: () => void;
 }
 
 export interface PageComposerProps {
@@ -117,10 +206,321 @@ function MetadataNameFieldBlock({ node, data }: RegistryComponentProps) {
   );
 }
 
+function ReviewSheetBlock({ node, data }: RegistryComponentProps) {
+  const review = data as ReviewSheetData | undefined;
+  if (!review) {
+    throw new Error(`Missing data for component ${node.componentId} at node ${node.id}`);
+  }
+
+  const { t } = review;
+
+  return (
+    <section className="review-page" data-node-id={node.id}>
+      <h2>{t.REVIEW}</h2>
+      <header className="review-hero">
+        <div>
+          <h3 className="review-character-name">{review.characterName}</h3>
+          <p className="review-character-meta">
+            {t.RACE_LABEL}: <strong>{review.selectedRaceName}</strong> |{" "}
+            {t.CLASS_LABEL}: <strong>{review.selectedClassName}</strong>
+          </p>
+        </div>
+        <div className="review-actions">
+          <button onClick={review.onExportJson}>{t.EXPORT_JSON}</button>
+          <button onClick={review.onToggleProvenance}>{t.TOGGLE_PROVENANCE}</button>
+        </div>
+      </header>
+
+      <article className="sheet review-decisions">
+        <h3>{t.REVIEW_IDENTITY_PROGRESSION}</h3>
+        {review.identityRows.map((row) => (
+          <p key={row.label}>
+            {row.label}: {row.value}
+          </p>
+        ))}
+      </article>
+
+      <div className="review-stat-cards">
+        {review.statCards.map((card) => (
+          <article className="review-card" key={card.label}>
+            <h3>{card.label}</h3>
+            <p>{String(card.value)}</p>
+          </article>
+        ))}
+      </div>
+
+      <article className="sheet">
+        <h3>{t.REVIEW_SAVE_HP_BREAKDOWN}</h3>
+        <table className="review-table">
+          <thead>
+            <tr>
+              <th>{t.REVIEW_STAT_COLUMN}</th>
+              <th>{t.REVIEW_BASE_COLUMN}</th>
+              <th>{t.REVIEW_ABILITY_COLUMN}</th>
+              <th>{t.REVIEW_ADJUSTMENTS_COLUMN}</th>
+              <th>{t.REVIEW_FINAL_COLUMN}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {review.saveHpRows.map((row) => (
+              <tr key={row.label}>
+                <td className="review-cell-key">{row.label}</td>
+                <td>{row.base}</td>
+                <td>{row.ability}</td>
+                <td>{row.adjustments}</td>
+                <td>{row.final}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </article>
+
+      <article className="sheet">
+        <h3>{t.REVIEW_ATTACK_LINES}</h3>
+        <table className="review-table">
+          <thead>
+            <tr>
+              <th>{t.REVIEW_ATTACK_TYPE_COLUMN}</th>
+              <th>{t.REVIEW_ATTACK_ITEM_COLUMN}</th>
+              <th>{t.REVIEW_ATTACK_BONUS_COLUMN}</th>
+              <th>{t.REVIEW_DAMAGE_COLUMN}</th>
+              <th>{t.REVIEW_CRIT_COLUMN}</th>
+              <th>{t.REVIEW_RANGE_COLUMN}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {review.attackRows.map((row) => (
+              <tr key={row.id}>
+                <td className="review-cell-key">{row.typeLabel}</td>
+                <td>{row.name}</td>
+                <td>{row.attackBonus}</td>
+                <td>{row.damage}</td>
+                <td>{row.crit}</td>
+                <td>{row.range}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </article>
+
+      <article className="sheet">
+        <h3>{t.REVIEW_FEAT_SUMMARY}</h3>
+        {review.featSummary.length === 0 ? (
+          <p className="review-muted">-</p>
+        ) : (
+          <ul className="calc-list">
+            {review.featSummary.map((feat) => (
+              <li key={feat.id}>
+                <strong>{feat.name}</strong>: {feat.description}
+              </li>
+            ))}
+          </ul>
+        )}
+      </article>
+
+      <article className="sheet">
+        <h3>{t.REVIEW_TRAIT_SUMMARY}</h3>
+        {review.traitSummary.length === 0 ? (
+          <p className="review-muted">-</p>
+        ) : (
+          <ul className="calc-list">
+            {review.traitSummary.map((trait) => (
+              <li key={trait.id}>
+                <strong>{trait.name}</strong>: {trait.description}
+              </li>
+            ))}
+          </ul>
+        )}
+      </article>
+
+      <article className="sheet">
+        <h3>{t.REVIEW_ABILITY_BREAKDOWN}</h3>
+        <table className="review-table">
+          <caption className="sr-only">{t.REVIEW_ABILITY_TABLE_CAPTION}</caption>
+          <thead>
+            <tr>
+              <th>{t.REVIEW_ABILITY_COLUMN}</th>
+              <th>{t.REVIEW_BASE_COLUMN}</th>
+              <th>{t.REVIEW_ADJUSTMENTS_COLUMN}</th>
+              <th>{t.REVIEW_FINAL_COLUMN}</th>
+              <th>{t.REVIEW_MODIFIER_COLUMN}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {review.abilityRows.map((row) => (
+              <tr key={row.id}>
+                <td className="review-cell-key">{row.label}</td>
+                <td>{row.base}</td>
+                <td>
+                  {row.adjustments.length === 0 ? (
+                    <span className="review-muted">-</span>
+                  ) : (
+                    <ul className="calc-list">
+                      {row.adjustments.map((adjustment, index) => (
+                        <li key={`${row.id}-${index}`}>
+                          <code>{adjustment.value}</code> {adjustment.source}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </td>
+                <td>{row.final}</td>
+                <td>{row.mod}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </article>
+
+      <article className="sheet">
+        <h3>{t.REVIEW_COMBAT_BREAKDOWN}</h3>
+        <table className="review-table">
+          <caption className="sr-only">{t.REVIEW_COMBAT_TABLE_CAPTION}</caption>
+          <thead>
+            <tr>
+              <th>{t.REVIEW_STAT_COLUMN}</th>
+              <th>{t.REVIEW_BASE_COLUMN}</th>
+              <th>{t.REVIEW_ADJUSTMENTS_COLUMN}</th>
+              <th>{t.REVIEW_FINAL_COLUMN}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {review.combatRows.map((row) => (
+              <tr key={row.id}>
+                <td className="review-cell-key">{row.label}</td>
+                <td>{row.base}</td>
+                <td>
+                  {row.adjustments.length === 0 ? (
+                    <span className="review-muted">-</span>
+                  ) : (
+                    <ul className="calc-list">
+                      {row.adjustments.map((adjustment, index) => (
+                        <li key={`${row.id}-${index}`}>
+                          <code>{adjustment.value}</code> {adjustment.source}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </td>
+                <td>{row.final}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </article>
+
+      <article className="sheet">
+        <h3>{t.REVIEW_SKILLS_BREAKDOWN}</h3>
+        <p className="review-skills-summary">
+          {t.REVIEW_POINTS_SPENT_LABEL} {review.skillsSummary.spent} / {review.skillsSummary.total} (
+          {review.skillsSummary.remaining} {t.REVIEW_REMAINING_LABEL})
+        </p>
+        <table className="review-table">
+          <caption className="sr-only">{t.REVIEW_SKILLS_TABLE_CAPTION}</caption>
+          <thead>
+            <tr>
+              <th>{t.REVIEW_SKILL_COLUMN}</th>
+              <th>{t.REVIEW_RANKS_COLUMN}</th>
+              <th>{t.REVIEW_ABILITY_COLUMN}</th>
+              <th>{t.REVIEW_RACIAL_COLUMN}</th>
+              <th>{t.REVIEW_MISC_COLUMN}</th>
+              <th>{t.REVIEW_ACP_COLUMN}</th>
+              <th>{t.REVIEW_TOTAL_COLUMN}</th>
+              <th>{t.REVIEW_POINT_COST_COLUMN}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {review.skillsRows.map((row) => (
+              <tr key={row.id}>
+                <td className="review-cell-key">{row.name}</td>
+                <td>{row.ranks}</td>
+                <td>{row.ability}</td>
+                <td>{row.racial}</td>
+                <td>{row.misc}</td>
+                <td>{row.acp}</td>
+                <td>{row.total}</td>
+                <td>{row.pointCost}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </article>
+
+      <article className="sheet">
+        <h3>{t.REVIEW_EQUIPMENT_LOAD}</h3>
+        <p>
+          {t.REVIEW_SELECTED_ITEMS_LABEL}: {review.equipmentLoad.selectedItems}
+        </p>
+        <p>
+          {t.REVIEW_TOTAL_WEIGHT_LABEL}: {review.equipmentLoad.totalWeight}
+        </p>
+        <p>
+          {t.REVIEW_LOAD_CATEGORY_LABEL}: {review.equipmentLoad.loadCategory}
+        </p>
+        <p>
+          {t.REVIEW_SPEED_IMPACT_LABEL}: {review.equipmentLoad.speedImpact}
+        </p>
+      </article>
+
+      <article className="sheet">
+        <h3>{t.REVIEW_MOVEMENT_DETAIL}</h3>
+        <p>
+          {t.REVIEW_SPEED_BASE_LABEL}: {review.movementDetail.base}
+        </p>
+        <p>
+          {t.REVIEW_SPEED_ADJUSTED_LABEL}: {review.movementDetail.adjusted}
+        </p>
+        <p>
+          {t.REVIEW_MOVEMENT_NOTES_LABEL}: {review.movementDetail.notes}
+        </p>
+      </article>
+
+      <article className="sheet review-decisions">
+        <h3>{t.REVIEW_RULES_DECISIONS}</h3>
+        <p>
+          {t.REVIEW_FAVORED_CLASS_LABEL}: {review.rulesDecisions.favoredClass}
+        </p>
+        <p>
+          {t.REVIEW_MULTICLASS_XP_IGNORED_LABEL}: {review.rulesDecisions.ignoresMulticlassXpPenalty}
+        </p>
+        <p>
+          {t.REVIEW_FEAT_SLOTS_LABEL}: {review.rulesDecisions.featSelectionLimit}
+        </p>
+      </article>
+
+      <article className="sheet review-decisions">
+        <h3>{t.REVIEW_PACK_INFO}</h3>
+        <p>
+          {t.REVIEW_SELECTED_EDITION_LABEL}: {review.packInfo.selectedEdition}
+        </p>
+        <p>{t.REVIEW_ENABLED_PACKS_LABEL}:</p>
+        <ul>
+          {review.packInfo.enabledPacks.map((pack) => (
+            <li key={pack.packId}>
+              {pack.packId} ({pack.version})
+            </li>
+          ))}
+        </ul>
+        <p>
+          {t.REVIEW_FINGERPRINT_LABEL}: <code>{review.packInfo.fingerprint}</code>
+        </p>
+      </article>
+
+      {review.showProvenance && (
+        <article className="sheet">
+          <h3>{t.REVIEW_RAW_PROVENANCE}</h3>
+          <pre>{review.provenanceJson}</pre>
+        </article>
+      )}
+    </section>
+  );
+}
+
 const componentRegistry: Record<string, (props: RegistryComponentProps) => ReactNode> = {
   "layout.singleColumn": SingleColumnLayout,
   "entityType.singleSelect": EntityTypeSingleSelectBlock,
   "metadata.nameField": MetadataNameFieldBlock,
+  "review.sheet": ReviewSheetBlock,
 };
 
 function renderNode(node: PageSchemaNode, dataRoot: Record<string, unknown>): ReactNode {

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -300,6 +300,7 @@ const AllowedPageComponentIds = [
   "layout.twoColumn",
   "entityType.singleSelect",
   "metadata.nameField",
+  "review.sheet",
   "metadataNameField",
   "metadataCharacterDetails",
   "reviewHero",

--- a/packages/schema/src/pageSchema.test.ts
+++ b/packages/schema/src/pageSchema.test.ts
@@ -43,6 +43,26 @@ describe("page schema", () => {
     expect(parsed.root.children?.[0]?.componentId).toBe("entityType.singleSelect");
   });
 
+  it("accepts review sheet blocks in the closed component registry", () => {
+    const parsed = PageSchema.parse({
+      id: "character.review",
+      root: {
+        id: "review-root",
+        componentId: "layout.singleColumn",
+        children: [
+          {
+            id: "review-sheet",
+            componentId: "review.sheet",
+            slot: "main",
+            dataSource: "page.reviewSheet"
+          }
+        ]
+      }
+    });
+
+    expect(parsed.root.children?.[0]?.componentId).toBe("review.sheet");
+  });
+
   it("rejects unknown component ids", () => {
     expect(() =>
       PageSchema.parse({

--- a/packs/srd-35e-minimal/flows/character-creation.flow.json
+++ b/packs/srd-35e-minimal/flows/character-creation.flow.json
@@ -142,6 +142,7 @@
       "id": "review",
       "kind": "review",
       "label": "Review",
+      "pageSchemaId": "character.review",
       "source": {
         "type": "manual"
       }

--- a/packs/srd-35e-minimal/ui/pages/character.review.page.json
+++ b/packs/srd-35e-minimal/ui/pages/character.review.page.json
@@ -1,0 +1,15 @@
+{
+  "id": "character.review",
+  "root": {
+    "id": "review-root",
+    "componentId": "layout.singleColumn",
+    "children": [
+      {
+        "id": "review-sheet",
+        "componentId": "review.sheet",
+        "slot": "main",
+        "dataSource": "page.reviewSheet"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- migrate the review step onto the schema-driven page composer path
- add a pack-owned \\character.review\\ page schema and closed registry support for \\eview.sheet\\
- keep existing review layout/visual output stable while moving rendering behind prepared page context

## Test Plan
- [x] npm --workspace @dcb/schema run test
- [x] npm --workspace @dcb/datapack run test
- [x] npm --workspace @dcb/web run test
- [x] npm run typecheck
- [x] \\='1'; npx playwright test tests/visual/wizard.visual.spec.ts --grep " detail page\