### PR TITLE
fix(engine): harden compute CharacterSpec contract validation

### DIFF
--- a/packages/engine/src/characterSpec.test.ts
+++ b/packages/engine/src/characterSpec.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { normalizeCharacterSpec, validateCharacterSpec } from "./characterSpec";
+
+describe("validateCharacterSpec", () => {
+  const baseSpec = {
+    meta: { rulesetId: "dnd35e", sourceIds: ["srd-35e-minimal"] },
+    abilities: { str: 10, dex: 10, con: 10, int: 10, wis: 10, cha: 10 }
+  };
+
+  it("reports SPEC_CLASS_LEVEL_INVALID for raw string class levels", () => {
+    const issues = validateCharacterSpec({
+      ...baseSpec,
+      class: { classId: "fighter", level: "2" as unknown as number }
+    });
+
+    expect(issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "SPEC_CLASS_LEVEL_INVALID",
+          path: "class.level"
+        })
+      ])
+    );
+  });
+
+  it("reports SPEC_CLASS_LEVEL_INVALID for raw boolean class levels", () => {
+    const issues = validateCharacterSpec({
+      ...baseSpec,
+      class: { classId: "fighter", level: true as unknown as number }
+    });
+
+    expect(issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "SPEC_CLASS_LEVEL_INVALID",
+          path: "class.level"
+        })
+      ])
+    );
+  });
+});
+
+describe("normalizeCharacterSpec", () => {
+  it("does not preserve non-number class levels through normalization", () => {
+    const normalized = normalizeCharacterSpec({
+      meta: { rulesetId: "dnd35e", sourceIds: ["srd-35e-minimal"] },
+      class: { classId: "fighter", level: "2" as unknown as number },
+      abilities: { str: 10, dex: 10, con: 10, int: 10, wis: 10, cha: 10 }
+    });
+
+    expect(normalized.class?.level).toBe(1);
+  });
+});

--- a/packages/engine/src/characterSpec.ts
+++ b/packages/engine/src/characterSpec.ts
@@ -70,7 +70,7 @@ function normalizeClassSelection(
   if (!value) return undefined;
   const classId = normalizeId(value.classId);
   if (!classId) return undefined;
-  const level = Number(value.level);
+  const level = typeof value.level === "number" ? value.level : Number.NaN;
   return {
     classId,
     level: Number.isFinite(level) && level >= 1 ? Math.floor(level) : 1
@@ -158,8 +158,8 @@ export function validateCharacterSpec(spec: CharacterSpec): CharacterSpecValidat
   }
 
   if (spec.class !== undefined && spec.class !== null && typeof spec.class === "object") {
-    const rawLevel = Number((spec.class as { level?: unknown }).level);
-    if (!Number.isInteger(rawLevel) || rawLevel < 1) {
+    const rawLevel = (spec.class as { level?: unknown }).level;
+    if (typeof rawLevel !== "number" || !Number.isInteger(rawLevel) || rawLevel < 1) {
       issues.push({
         code: "SPEC_CLASS_LEVEL_INVALID",
         message: "class.level must be an integer >= 1.",

--- a/packages/engine/src/engine.test.ts
+++ b/packages/engine/src/engine.test.ts
@@ -2677,6 +2677,40 @@ describe("compute() contract", () => {
     );
   });
 
+  it("defaults malformed non-numeric ability values instead of silently coercing them", () => {
+    const malformedSpec = {
+      meta: { name: "Hidden Coercion", rulesetId: "dnd35e", sourceIds: ["srd-35e-minimal"] },
+      raceId: "human",
+      class: { classId: "fighter", level: 1 },
+      abilities: {
+        str: null,
+        dex: false,
+        con: "   ",
+        int: 10,
+        wis: 10,
+        cha: 10
+      },
+      featIds: ["power-attack"],
+      skillRanks: { climb: 4 }
+    } as unknown as Parameters<typeof compute>[0];
+
+    const result = compute(malformedSpec, {
+      resolvedData: context.resolvedData,
+      enabledPackIds: context.enabledPackIds
+    });
+
+    expect(result.sheetViewModel.data.review.abilities.str).toEqual({ score: 10, mod: 0 });
+    expect(result.sheetViewModel.data.review.abilities.dex).toEqual({ score: 10, mod: 0 });
+    expect(result.sheetViewModel.data.review.abilities.con).toEqual({ score: 10, mod: 0 });
+    expect(result.assumptions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "SPEC_ABILITY_DEFAULTED", path: "abilities.str" }),
+        expect.objectContaining({ code: "SPEC_ABILITY_DEFAULTED", path: "abilities.dex" }),
+        expect.objectContaining({ code: "SPEC_ABILITY_DEFAULTED", path: "abilities.con" })
+      ])
+    );
+  });
+
   it("defaults malformed ability values that throw on numeric coercion without crashing compute", () => {
     const malformedSpec = {
       meta: { name: "Symbol Ability", rulesetId: "dnd35e", sourceIds: ["srd-35e-minimal"] },

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -446,27 +446,38 @@ function sanitizeStateForComputeOutput(
   let nextState: CharacterState | undefined;
   const assumptions: ComputeResultAssumptionEntry[] = [];
 
-  const toFiniteNumber = (value: unknown): number => {
+  const toSanitizedAbilityScore = (
+    value: unknown
+  ): { valid: true; numeric: number } | { valid: false } => {
+    if (typeof value === "number") {
+      return Number.isFinite(value) ? { valid: true, numeric: value } : { valid: false };
+    }
+    if (typeof value !== "string") return { valid: false };
+
+    const trimmed = value.trim();
+    if (!trimmed) return { valid: false };
+    if (!/^[+-]?(?:\d+\.?\d*|\.\d+)$/.test(trimmed)) return { valid: false };
+
     try {
-      const numeric = Number(value);
-      return Number.isFinite(numeric) ? numeric : Number.NaN;
+      const numeric = Number(trimmed);
+      return Number.isFinite(numeric) ? { valid: true, numeric } : { valid: false };
     } catch {
-      return Number.NaN;
+      return { valid: false };
     }
   };
 
   for (const ability of ABILITY_KEYS) {
     const score = state.abilities[ability];
-    const numericScore = toFiniteNumber(score);
+    const sanitizedScore = toSanitizedAbilityScore(score);
 
-    if (Number.isFinite(numericScore)) {
+    if (sanitizedScore.valid) {
       if (typeof score === "number") continue;
 
       nextState ??= {
         ...state,
         abilities: { ...state.abilities }
       };
-      nextState.abilities[ability] = numericScore;
+      nextState.abilities[ability] = sanitizedScore.numeric;
       continue;
     }
 


### PR DESCRIPTION
## Summary
- stop compute validation from inheriting flow-default ability modes for flow-independent CharacterSpec input
- sanitize non-finite ability scores before compute output serialization and record explicit assumptions
- validate raw class level input before normalization hides invalid values and add regression coverage for malformed class input

## Verification
- npm --workspace @dcb/engine run test -- src/engine.test.ts
- npm --workspace @dcb/engine run typecheck

Closes #176
Closes #177
Closes #178