### PR TITLE
refactor(engine): move wizard apis behind legacy entrypoint

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -4,12 +4,14 @@ import type { Page } from "@dcb/schema";
 import { loadMinimalPack } from "./loadMinimalPack";
 import {
   DEFAULT_STATS,
-  applyChoice,
   compute,
+} from "@dcb/engine";
+import {
+  applyChoice,
   initialState,
   listChoices,
   type CharacterState,
-} from "@dcb/engine";
+} from "@dcb/engine/legacy";
 import {
   EDITIONS,
   FALLBACK_EDITION,

--- a/apps/web/src/characterSpecFromState.test.ts
+++ b/apps/web/src/characterSpecFromState.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { type CharacterState } from "@dcb/engine";
+import { type CharacterState } from "@dcb/engine/legacy";
 import { characterSpecFromState } from "./characterSpecFromState";
 
 describe("characterSpecFromState", () => {

--- a/apps/web/src/characterSpecFromState.ts
+++ b/apps/web/src/characterSpecFromState.ts
@@ -1,4 +1,5 @@
-import type { CharacterSpec, CharacterState } from "@dcb/engine";
+import type { CharacterSpec } from "@dcb/engine";
+import type { CharacterState } from "@dcb/engine/legacy";
 
 type CharacterSpecFromStateInput = {
   state: CharacterState;

--- a/docs/data/CHARACTER_SPEC_V1.md
+++ b/docs/data/CHARACTER_SPEC_V1.md
@@ -71,7 +71,12 @@ Unknown wizard-only step state should not be copied into `CharacterSpec`.
 
 ### `CharacterSpec` -> `CharacterState` (temporary bridge)
 
-The engine exports `characterSpecToState(spec)` to preserve compatibility while `compute(spec, rulepack)` replaces wizard-oriented internals.
+The temporary `characterSpecToState(spec)` bridge remains available from the internal `packages/engine/src/characterSpec.ts` module for engine migration work, but it is not part of the public package surface.
+
+The package surface is now split deliberately:
+
+- `@dcb/engine` exposes the flow-independent contract (`compute(spec, rulepack)`, CharacterSpec validation, and ComputeResult-facing types/constants).
+- `@dcb/engine/legacy` exposes the temporary wizard/state APIs (`initialState`, `applyChoice`, `listChoices`, `validateState`, `finalizeCharacter`, and related state types) for migration work.
 
 - `meta.name` -> `metadata.name`
 - `abilities` -> `abilities`

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { ContractFixtureSchema } from "@dcb/schema";
 import { resolvePackSet } from "@dcb/datapack/node";
-import { applyChoice, finalizeCharacter, initialState, listChoices, validateState, type CharacterState } from "@dcb/engine";
+import { applyChoice, finalizeCharacter, initialState, listChoices, validateState, type CharacterState } from "@dcb/engine/legacy";
 export { runAuthenticityChecks } from "./authenticity";
 import { assertPackReferenceIntegrity } from "./references";
 

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -2,7 +2,11 @@
   "name": "@dcb/engine",
   "version": "0.1.0",
   "type": "module",
-  "main": "src/index.ts",
+  "main": "src/public.ts",
+  "exports": {
+    ".": "./src/public.ts",
+    "./legacy": "./src/legacy.ts"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json --noEmit",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/engine/src/engine.test.ts
+++ b/packages/engine/src/engine.test.ts
@@ -4,17 +4,21 @@ import { describe, expect, it } from "vitest";
 import type { LoadedPack } from "@dcb/datapack";
 import { resolveLoadedPacks } from "@dcb/datapack";
 import { resolvePackSet } from "@dcb/datapack/node";
+import * as enginePublicApi from "./public";
+import * as engineLegacyApi from "./legacy";
+import {
+  normalizeCharacterSpec,
+  validateCharacterSpec,
+  compute
+} from "./public";
 import {
   finalizeCharacter,
   initialState,
   applyChoice,
   listChoices,
-  validateState,
-  normalizeCharacterSpec,
-  characterSpecToState,
-  validateCharacterSpec,
-  compute
-} from "./index";
+  validateState
+} from "./legacy";
+import { characterSpecToState } from "./characterSpec";
 
 const resolved = resolvePackSet(path.resolve(process.cwd(), "../../packs"), ["srd-35e-minimal"]);
 const context = { enabledPackIds: ["srd-35e-minimal"], resolvedData: resolved };
@@ -2277,6 +2281,21 @@ describe("engine determinism", () => {
 });
 
 describe("CharacterSpec v1", () => {
+  it("keeps legacy wizard/state APIs off the top-level engine surface and behind the legacy entrypoint", () => {
+    expect("characterSpecToState" in enginePublicApi).toBe(false);
+    expect("initialState" in enginePublicApi).toBe(false);
+    expect("applyChoice" in enginePublicApi).toBe(false);
+    expect("listChoices" in enginePublicApi).toBe(false);
+    expect("validateState" in enginePublicApi).toBe(false);
+    expect("finalizeCharacter" in enginePublicApi).toBe(false);
+
+    expect("initialState" in engineLegacyApi).toBe(true);
+    expect("applyChoice" in engineLegacyApi).toBe(true);
+    expect("listChoices" in engineLegacyApi).toBe(true);
+    expect("validateState" in engineLegacyApi).toBe(true);
+    expect("finalizeCharacter" in engineLegacyApi).toBe(true);
+  });
+
   it("normalizes a minimal flow-independent spec and passes validation", () => {
     const normalized = normalizeCharacterSpec({
       meta: {

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -80,7 +80,6 @@ export type {
   CharacterState
 } from "./characterSpec";
 export {
-  characterSpecToState,
   normalizeCharacterSpec,
   validateCharacterSpec
 } from "./characterSpec";

--- a/packages/engine/src/legacy.ts
+++ b/packages/engine/src/legacy.ts
@@ -1,0 +1,15 @@
+export {
+  finalizeCharacter,
+  initialState,
+  applyChoice,
+  listChoices,
+  validateState
+} from "./index";
+
+export type {
+  CharacterState,
+  EngineContext,
+  Choice,
+  ValidationError,
+  CharacterSheet
+} from "./index";

--- a/packages/engine/src/public.ts
+++ b/packages/engine/src/public.ts
@@ -1,0 +1,36 @@
+export {
+  COMPUTE_RESULT_SCHEMA_VERSION,
+  compute,
+  DEFAULT_STATS
+} from "./index";
+
+export type {
+  CharacterSpec,
+  CharacterSpecClassSelection,
+  CharacterSpecMeta,
+  CharacterSpecValidationIssue,
+  ComputeResultValidationIssue,
+  ComputeResultUnresolvedEntry,
+  ComputeResultAssumptionEntry,
+  VersionedSheetViewModel,
+  ComputeResult,
+  RulepackInput,
+  ProvenanceRecord,
+  SkillBreakdown,
+  SkillMiscBreakdownEntry,
+  RacialModifierBreakdown,
+  SpellDcBonusBreakdown,
+  InnateSpellLikeAbilityBreakdown,
+  DecisionSummary,
+  AttackLine,
+  AttackBonusBreakdown,
+  SheetViewModel,
+  Phase1Sheet,
+  Phase2Sheet,
+  UnresolvedRule
+} from "./index";
+
+export {
+  normalizeCharacterSpec,
+  validateCharacterSpec
+} from "./characterSpec";


### PR DESCRIPTION
## Summary
- introduce explicit `@dcb/engine/legacy` and reserve top-level `@dcb/engine` for the flow-independent contract surface
- migrate in-repo wizard/state consumers to the legacy entrypoint without changing behavior
- add public-surface coverage and update CharacterSpec contract docs to reflect the split

## Test Plan
- [x] `npm run test -- src/engine.test.ts` in `packages/engine`
- [x] `npm run test -- src/characterSpecFromState.test.ts` in `apps/web`
- [x] `npm run test -- src/App.test.tsx` in `apps/web`
- [x] `npm run test -- src/pageComposer/PageComposer.test.tsx` in `apps/web`
- [x] repo-root `npm run typecheck`