### PR TITLE
[P0] Add CharacterSpec-based compute contract fixtures (issue #204)

### DIFF
--- a/packages/contracts/src/contracts.test.ts
+++ b/packages/contracts/src/contracts.test.ts
@@ -118,6 +118,83 @@ describe("pack contracts", () => {
     });
   });
 
+  it("runs CharacterSpec-based compute fixtures alongside legacy action fixtures", () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "dcb-compute-contract-"));
+    const packSource = path.resolve(process.cwd(), "../../packs/srd-35e-minimal");
+    const packDest = path.join(tempRoot, "srd-35e-minimal");
+
+    fs.cpSync(packSource, packDest, { recursive: true });
+    fs.writeFileSync(
+      path.join(packDest, "contracts/human-fighter-1-compute.json"),
+      JSON.stringify(
+        {
+          enabledPacks: ["srd-35e-minimal"],
+          characterSpec: {
+            meta: {
+              name: "Aric",
+              rulesetId: "dnd35e",
+              sourceIds: ["srd-35e-minimal"]
+            },
+            raceId: "human",
+            class: {
+              classId: "fighter",
+              level: 1
+            },
+            abilities: {
+              str: 16,
+              dex: 12,
+              con: 14,
+              int: 10,
+              wis: 10,
+              cha: 8
+            },
+            skillRanks: {
+              climb: 4,
+              jump: 3,
+              diplomacy: 0.5
+            },
+            featIds: ["power-attack"],
+            equipmentIds: ["longsword", "chainmail", "heavy-wooden-shield"]
+          },
+          contractClarifications: {
+            goldenPath: "Canonical compute contract fixture using CharacterSpec input."
+          },
+          expected: {
+            validationIssueCodes: [],
+            computeResultSubset: {
+              schemaVersion: "0.1",
+              sheetViewModel: {
+                schemaVersion: "0.1",
+                data: {
+                  combat: {
+                    ac: {
+                      total: 18
+                    },
+                    attacks: [
+                      {
+                        itemId: "longsword",
+                        attackBonus: 4,
+                        damageLine: "1d8+3"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        null,
+        2
+      )
+    );
+
+    try {
+      expect(() => runContracts(tempRoot)).not.toThrow();
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   it("fails when a contract fixture contains non-ASCII text", () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "dcb-contract-ascii-"));
     const packSource = path.resolve(process.cwd(), "../../packs/srd-35e-minimal");

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,7 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
-import { ContractFixtureSchema } from "@dcb/schema";
+import { ContractFixtureSchema, type ContractFixture } from "@dcb/schema";
 import { resolvePackSet } from "@dcb/datapack/node";
+import { compute, type CharacterSpec } from "@dcb/engine";
 import { applyChoice, finalizeCharacter, initialState, listChoices, validateState, type CharacterState } from "@dcb/engine/legacy";
 export { runAuthenticityChecks } from "./authenticity";
 import { assertPackReferenceIntegrity } from "./references";
@@ -101,6 +102,17 @@ function contractFailure(packId: string, fixtureFile: string, message: string, e
   ].join("\n"));
 }
 
+type ComputeContractFixture = Extract<ContractFixture, { characterSpec: Record<string, unknown> }>;
+type LegacyContractFixture = Extract<ContractFixture, { initialState: Record<string, unknown> }>;
+
+function isComputeContractFixture(fixture: ContractFixture): fixture is ComputeContractFixture {
+  return "characterSpec" in fixture;
+}
+
+function isLegacyContractFixture(fixture: ContractFixture): fixture is LegacyContractFixture {
+  return "initialState" in fixture;
+}
+
 export function runContracts(packsRoot: string): void {
   assertContractFixturesUseAscii(packsRoot);
   assertPackReferenceIntegrity(packsRoot);
@@ -117,6 +129,25 @@ export function runContracts(packsRoot: string): void {
       const fixture = ContractFixtureSchema.parse(JSON.parse(fs.readFileSync(fixturePath, "utf8")));
       const resolved = resolvePackSet(packsRoot, fixture.enabledPacks);
       const context = { enabledPackIds: fixture.enabledPacks, resolvedData: resolved };
+
+      if (isComputeContractFixture(fixture)) {
+        const result = compute(fixture.characterSpec as unknown as CharacterSpec, context);
+        const validationIssueCodes = result.validationIssues.map((issue) => issue.code);
+        const expectedValidationIssueCodes = fixture.expected.validationIssueCodes;
+        if (expectedValidationIssueCodes && !arraysEqual(validationIssueCodes, expectedValidationIssueCodes)) {
+          contractFailure(packId, file, "Validation issue codes mismatch", expectedValidationIssueCodes, validationIssueCodes);
+        }
+
+        if (fixture.expected.computeResultSubset && !containsSubset(result as unknown as Record<string, unknown>, fixture.expected.computeResultSubset)) {
+          contractFailure(packId, file, "ComputeResult subset mismatch", fixture.expected.computeResultSubset, result);
+        }
+        continue;
+      }
+
+      if (!isLegacyContractFixture(fixture)) {
+        contractFailure(packId, file, "Unsupported contract fixture shape", "legacy or compute fixture", fixture);
+      }
+
       let state: CharacterState = { ...initialState, ...(fixture.initialState as Partial<CharacterState>) };
       for (const action of fixture.actions) {
         state = applyChoice(state, action.choiceId, action.selection, context);

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -788,7 +788,7 @@ export const PackLocaleSchema = z.object({
   entityText: z.record(z.record(z.record(z.string()))).optional()
 });
 
-export const ContractFixtureSchema = z.object({
+const LegacyContractFixtureSchema = z.object({
   enabledPacks: z.array(z.string()),
   initialState: z.record(z.any()),
   actions: z.array(z.object({ choiceId: z.string(), selection: z.any() })),
@@ -799,6 +799,21 @@ export const ContractFixtureSchema = z.object({
     finalSheetSubset: z.record(z.any()).optional()
   })
 });
+
+const ComputeContractFixtureSchema = z.object({
+  enabledPacks: z.array(z.string()),
+  characterSpec: z.record(z.any()),
+  contractClarifications: z.record(z.string()).optional(),
+  expected: z.object({
+    validationIssueCodes: z.array(z.string()).optional(),
+    computeResultSubset: z.record(z.any()).optional()
+  })
+});
+
+export const ContractFixtureSchema = z.union([
+  LegacyContractFixtureSchema,
+  ComputeContractFixtureSchema
+]);
 
 export const OfficialSourceSchema = z.object({
   title: z.string().min(1),

--- a/packs/srd-35e-minimal/contracts/human-fighter-1-compute.json
+++ b/packs/srd-35e-minimal/contracts/human-fighter-1-compute.json
@@ -1,0 +1,88 @@
+{
+  "enabledPacks": [
+    "srd-35e-minimal"
+  ],
+  "characterSpec": {
+    "meta": {
+      "name": "Aric",
+      "rulesetId": "dnd35e",
+      "sourceIds": ["srd-35e-minimal"]
+    },
+    "raceId": "human",
+    "class": {
+      "classId": "fighter",
+      "level": 1
+    },
+    "abilities": {
+      "str": 16,
+      "dex": 12,
+      "con": 14,
+      "int": 10,
+      "wis": 10,
+      "cha": 8
+    },
+    "skillRanks": {
+      "climb": 4,
+      "jump": 3,
+      "diplomacy": 0.5
+    },
+    "featIds": ["power-attack"],
+    "equipmentIds": ["longsword", "chainmail", "heavy-wooden-shield"]
+  },
+  "contractClarifications": {
+    "goldenPath": "Canonical compute contract fixture using flow-independent CharacterSpec input.",
+    "stats": "Human Fighter 1 via compute(spec, rulepack): hp=12, ac=18, first melee attack bonus=4, speed=20 in chainmail."
+  },
+  "expected": {
+    "validationIssueCodes": [],
+    "computeResultSubset": {
+      "schemaVersion": "0.1",
+      "sheetViewModel": {
+        "schemaVersion": "0.1",
+        "data": {
+          "combat": {
+            "ac": {
+              "total": 18,
+              "touch": 11,
+              "flatFooted": 17
+            },
+            "attacks": [
+              {
+                "itemId": "longsword",
+                "name": "Longsword",
+                "category": "melee",
+                "attackBonus": 4,
+                "damage": "1d8",
+                "damageLine": "1d8+3",
+                "crit": "19-20/x2"
+              }
+            ]
+          },
+          "review": {
+            "hp": {
+              "total": 12
+            },
+            "skillBudget": {
+              "total": 12,
+              "spent": 8,
+              "remaining": 4
+            }
+          }
+        }
+      },
+      "validationIssues": [],
+      "assumptions": [],
+      "unresolved": [
+        {
+          "code": "srd-35e-minimal:classes:fighter:fighter-bonus-feat-runtime"
+        },
+        {
+          "code": "srd-35e-minimal:classes:fighter:fighter-proficiency-automation"
+        },
+        {
+          "code": "srd-35e-minimal:feats:power-attack:power-attack-benefit"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add CharacterSpec-based compute fixtures alongside legacy action fixtures
- teach the shared contracts runner to execute flow-independent compute cases
- commit the first compute fixture under packs/srd-35e-minimal/contracts

## Issue
- closes #204

## Verification
- npm --workspace @dcb/contracts run test
- npm --workspace @dcb/contracts run typecheck
- npm --workspace @dcb/schema run typecheck
- npm run check:contract-fixtures
- npm run typecheck