### PR TITLE
[P0] Route compute through internal helpers (issue #205)

### DIFF
--- a/docs/data/COMPUTE_RESULT_V1.md
+++ b/docs/data/COMPUTE_RESULT_V1.md
@@ -82,8 +82,8 @@ This is covered by engine tests under `compute() contract`, including a determin
 
 ## Migration note
 
-`compute()` currently bridges into legacy engine internals through `characterSpecToState(spec)`, `validateState()`, and `finalizeCharacter()`.
+`compute()` now builds its own internal state from normalized `CharacterSpec` input and calls shared internal validation/finalization helpers instead of routing directly through the exported legacy wizard/state APIs.
 
-This preserves current behavior while decoupling the public contract from wizard flow state. The top-level `@dcb/engine` package surface is now reserved for the flow-independent contract; temporary wizard/state APIs live under the explicit `@dcb/engine/legacy` entrypoint.
+This preserves current behavior while further decoupling the public contract from wizard flow state. The top-level `@dcb/engine` package surface is now reserved for the flow-independent contract; temporary wizard/state APIs live under the explicit `@dcb/engine/legacy` entrypoint as thin compatibility wrappers.
 
 A later internal refactor can replace the bridge without changing the `ComputeResult` public shape.

--- a/packages/engine/src/engine.test.ts
+++ b/packages/engine/src/engine.test.ts
@@ -2410,6 +2410,19 @@ describe("CharacterSpec v1", () => {
 });
 
 describe("compute() contract", () => {
+  it("keeps compute() off the legacy bridge exports", () => {
+    const engineSource = fs.readFileSync(new URL("./index.ts", import.meta.url), "utf8");
+    const computeStart = engineSource.indexOf("export function compute(");
+    const computeEnd = engineSource.indexOf("type DeferredMechanicRecord =", computeStart);
+    const computeSource = engineSource.slice(computeStart, computeEnd);
+
+    expect(computeStart).toBeGreaterThanOrEqual(0);
+    expect(computeEnd).toBeGreaterThan(computeStart);
+    expect(computeSource).not.toContain("characterSpecToState(");
+    expect(computeSource).not.toContain("validateState(");
+    expect(computeSource).not.toContain("finalizeCharacter(");
+  });
+
   it("returns versioned ComputeResult for a canonical CharacterSpec", () => {
     const result = compute(
       {

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -1,7 +1,6 @@
 import type { Constraint, Effect, Entity, Expr } from "@dcb/schema";
 import type { ResolvedEntity, ResolvedPackSet } from "@dcb/datapack";
 import {
-  characterSpecToState,
   normalizeCharacterSpec,
   validateCharacterSpec,
   type CharacterSpec,
@@ -439,6 +438,27 @@ function mapStepIdToSpecPath(stepId: string): string | undefined {
   return STEP_ID_TO_SPEC_PATH[stepId];
 }
 
+function buildComputeStateFromSpec(spec: CharacterSpec): CharacterState {
+  const hasSkillRanks = Object.keys(spec.skillRanks ?? {}).length > 0;
+  const classId = spec.class
+    ? spec.class.level > 1
+      ? `${spec.class.classId.replace(/-\d+$/, "")}-${spec.class.level}`
+      : spec.class.classId.replace(/-\d+$/, "")
+    : undefined;
+
+  return {
+    metadata: spec.meta.name?.length ? { name: spec.meta.name } : {},
+    abilities: { ...spec.abilities },
+    selections: {
+      ...(spec.raceId ? { race: spec.raceId } : {}),
+      ...(classId ? { class: classId } : {}),
+      ...(hasSkillRanks ? { skills: spec.skillRanks } : {}),
+      feats: spec.featIds ?? [],
+      equipment: spec.equipmentIds ?? []
+    }
+  };
+}
+
 function sanitizeStateForComputeOutput(
   state: CharacterState
 ): { state: CharacterState; assumptions: ComputeResultAssumptionEntry[] } {
@@ -525,7 +545,7 @@ export function compute(spec: CharacterSpec, rulepack: RulepackInput): ComputeRe
     }
   }
 
-  const state = characterSpecToState(normalizedSpec);
+  const state = buildComputeStateFromSpec(normalizedSpec);
   const context: EngineContext = {
     resolvedData: rulepack.resolvedData,
     enabledPackIds: rulepack.enabledPackIds ?? normalizedSpec.meta.sourceIds
@@ -535,7 +555,7 @@ export function compute(spec: CharacterSpec, rulepack: RulepackInput): ComputeRe
   assumptions.push(...sanitized.assumptions);
 
   validationIssues.push(
-    ...validateState(sanitized.state, context, { allowFlowDefaultAbilityMode: false }).map((issue) => ({
+    ...collectValidationErrorsFromState(sanitized.state, context, { allowFlowDefaultAbilityMode: false }).map((issue) => ({
       code: issue.code,
       severity: "error" as const,
       message: issue.message,
@@ -545,7 +565,7 @@ export function compute(spec: CharacterSpec, rulepack: RulepackInput): ComputeRe
     }))
   );
 
-  const sheet = finalizeCharacter(sanitized.state, context);
+  const sheet = buildCharacterSheetFromState(sanitized.state, context);
   const unresolved: ComputeResultUnresolvedEntry[] = sheet.unresolvedRules.map((entry) => ({
     code: entry.id,
     message: entry.description,
@@ -1347,7 +1367,7 @@ export function applyChoice(state: CharacterState, choiceId: string, selection: 
   return { ...state, selections: { ...state.selections, [choiceId]: selection } };
 }
 
-export function validateState(
+function collectValidationErrorsFromState(
   state: CharacterState,
   context: EngineContext,
   options?: { allowFlowDefaultAbilityMode?: boolean }
@@ -1571,6 +1591,14 @@ export function validateState(
   }
 
   return errors;
+}
+
+export function validateState(
+  state: CharacterState,
+  context: EngineContext,
+  options?: { allowFlowDefaultAbilityMode?: boolean }
+): ValidationError[] {
+  return collectValidationErrorsFromState(state, context, options);
 }
 
 function applyEffect(effect: Effect, sheet: Record<string, any>, provenance: ProvenanceRecord[], source: ProvenanceRecord["source"]): void {
@@ -1947,7 +1975,7 @@ function normalizeCritProfile(rawCrit: string | undefined): string {
   return "20/x2";
 }
 
-export function finalizeCharacter(state: CharacterState, context: EngineContext): CharacterSheet {
+function buildCharacterSheetFromState(state: CharacterState, context: EngineContext): CharacterSheet {
   const abilities = Object.fromEntries(
     Object.entries(state.abilities).map(([k, score]) => [k, { score, mod: abilityMod(score) }])
   );
@@ -2254,6 +2282,10 @@ export function finalizeCharacter(state: CharacterState, context: EngineContext)
     unresolvedRules,
     packSetFingerprint: context.resolvedData.fingerprint
   };
+}
+
+export function finalizeCharacter(state: CharacterState, context: EngineContext): CharacterSheet {
+  return buildCharacterSheetFromState(state, context);
 }
 
 export function buildSheetViewModel(


### PR DESCRIPTION
## Summary
- stop compute() from directly calling the exported legacy bridge helpers
- keep validateState/finalizeCharacter as thin legacy wrappers over shared internal helpers
- document the narrower internal compute boundary

## Issue
- closes #205

## Verification
- npm --workspace @dcb/engine run test
- npm run typecheck