### PR TITLE
fix(schema): require top-level compute fixture fields

### DIFF
--- a/packages/contracts/src/contracts.test.ts
+++ b/packages/contracts/src/contracts.test.ts
@@ -195,6 +195,45 @@ describe("pack contracts", () => {
     }
   });
 
+  it("rejects compute fixtures missing top-level CharacterSpec fields before compute() runs", () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "dcb-compute-contract-invalid-"));
+    const packSource = path.resolve(process.cwd(), "../../packs/srd-35e-minimal");
+    const packDest = path.join(tempRoot, "srd-35e-minimal");
+
+    fs.cpSync(packSource, packDest, { recursive: true });
+    fs.writeFileSync(
+      path.join(packDest, "contracts/invalid-compute.json"),
+      JSON.stringify(
+        {
+          enabledPacks: ["srd-35e-minimal"],
+          characterSpec: {},
+          expected: {
+            validationIssueCodes: []
+          }
+        },
+        null,
+        2
+      )
+    );
+
+    try {
+      let thrown: unknown;
+      try {
+        runContracts(tempRoot);
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBeDefined();
+      expect(thrown).not.toBeInstanceOf(TypeError);
+      const message = thrown instanceof Error ? thrown.message : String(thrown);
+      expect(message).toMatch(/characterSpec/i);
+      expect(message).toMatch(/meta|abilities/i);
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   it("fails when a contract fixture contains non-ASCII text", () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "dcb-contract-ascii-"));
     const packSource = path.resolve(process.cwd(), "../../packs/srd-35e-minimal");

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -802,7 +802,10 @@ const LegacyContractFixtureSchema = z.object({
 
 const ComputeContractFixtureSchema = z.object({
   enabledPacks: z.array(z.string()),
-  characterSpec: z.record(z.any()),
+  characterSpec: z.object({
+    meta: z.record(z.any()),
+    abilities: z.record(z.any())
+  }).passthrough(),
   contractClarifications: z.record(z.string()).optional(),
   expected: z.object({
     validationIssueCodes: z.array(z.string()).optional(),


### PR DESCRIPTION
## Summary
- require `characterSpec.meta` and `characterSpec.abilities` in compute fixtures
- add a regression test proving malformed compute fixtures fail before `compute()` can crash
- reopen the closed-unmerged #209 patch as a recovery PR

## Context
- fixes the unresolved review gap left in merged PR #206
- recovery for closed-unmerged PR #209
- closes #208

## Verification
- npm --workspace @dcb/contracts run test -- src/contracts.test.ts -t "rejects compute fixtures missing top-level CharacterSpec fields before compute() runs"
- npm --workspace @dcb/contracts run test
- npm --workspace @dcb/schema run typecheck
- npm --workspace @dcb/contracts run typecheck
- npm run check:contract-fixtures
- npm run typecheck
