### PR TITLE
feat: expand supported skill synergy data

### DIFF
--- a/packages/contracts/src/skillSynergyDataset.test.ts
+++ b/packages/contracts/src/skillSynergyDataset.test.ts
@@ -1,0 +1,51 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+type ConditionalModifier = {
+  id?: string;
+  source?: { ref?: string };
+  when?: { left?: { id?: string }; right?: number };
+  apply?: { target?: { id?: string }; bonus?: number; note?: string };
+};
+
+describe("skill synergy dataset", () => {
+  it("includes the full unconditional PHB 3.5 core skill synergy set supported by the current engine", () => {
+    const rulesPath = path.resolve(
+      process.cwd(),
+      "../../packs/srd-35e-minimal/entities/rules.json",
+    );
+    const rules = JSON.parse(fs.readFileSync(rulesPath, "utf8")) as Array<{
+      id?: string;
+      data?: { conditionalModifiers?: ConditionalModifier[] };
+    }>;
+    const synergyRule = rules.find((rule) => rule.id === "skill-synergy-core");
+    const modifiers = synergyRule?.data?.conditionalModifiers ?? [];
+    const byId = new Map(modifiers.map((modifier) => [modifier.id, modifier]));
+
+    const expectedIds = [
+      "synergy-tumble-balance",
+      "synergy-tumble-jump",
+      "synergy-jump-tumble",
+      "synergy-bluff-diplomacy",
+      "synergy-bluff-intimidate",
+      "synergy-bluff-sleight-of-hand",
+      "synergy-sense-motive-diplomacy",
+      "synergy-handle-animal-ride",
+      "synergy-knowledge-arcana-spellcraft",
+      "synergy-knowledge-local-gather-information",
+      "synergy-knowledge-nobility-and-royalty-diplomacy",
+      "synergy-survival-knowledge-nature",
+    ];
+
+    expect(modifiers).toHaveLength(expectedIds.length);
+
+    for (const id of expectedIds) {
+      expect(byId.has(id), `missing synergy rule ${id}`).toBe(true);
+      expect(byId.get(id)?.apply?.note).toMatch(/PHB 3\.5 Table 4-5/i);
+      expect(byId.get(id)?.when?.right).toBe(5);
+      expect(byId.get(id)?.apply?.bonus).toBe(2);
+      expect(byId.get(id)?.source?.ref).toBe(byId.get(id)?.when?.left?.id);
+    }
+  });
+});

--- a/packages/engine/src/engineSkillSynergyRules.test.ts
+++ b/packages/engine/src/engineSkillSynergyRules.test.ts
@@ -123,4 +123,26 @@ describe("engine determinism", () => {
       total: 3
     });
   });
+
+  it("applies additional unconditional PHB 3.5 synergy mappings from pack data", () => {
+    let state = applyChoice(initialState, "name", "ExpandedSynergySet");
+    state = applyChoice(state, "abilities", { str: 10, dex: 12, con: 10, int: 12, wis: 10, cha: 10 });
+    state = applyChoice(state, "race", "human");
+    state = applyChoice(state, "class", "fighter");
+    state = applyChoice(state, "skills", {
+      "handle-animal": 5,
+      "knowledge-arcana": 5,
+      "knowledge-local": 5,
+      "knowledge-nobility-and-royalty": 5,
+      survival: 5
+    }, context);
+
+    const sheet = finalizeCharacter(state, context);
+
+    expect(sheet.skills.ride?.miscBonus).toBe(2);
+    expect(sheet.skills.spellcraft?.miscBonus).toBe(2);
+    expect(sheet.skills["gather-information"]?.miscBonus).toBe(2);
+    expect(sheet.skills.diplomacy?.miscBonus).toBe(2);
+    expect(sheet.skills["knowledge-nature"]?.miscBonus).toBe(2);
+  });
 });

--- a/packs/srd-35e-minimal/authenticity.lock.json
+++ b/packs/srd-35e-minimal/authenticity.lock.json
@@ -32,7 +32,7 @@
     },
     {
       "path": "entities/rules.json",
-      "sha256": "49105f755f803b845dc5acbc29ffbd3ad6bf4032e0d9c7c4774f635a05b0b702"
+      "sha256": "1f3ad6bb2bf8d73f9279c6ff6a446155d287880621ddca355ae2c0c013b8488d"
     }
   ]
 }

--- a/packs/srd-35e-minimal/entities/rules.json
+++ b/packs/srd-35e-minimal/entities/rules.json
@@ -216,6 +216,126 @@
             "bonusType": "untyped",
             "note": "PHB 3.5 Table 4-5: 5 ranks in Sense Motive grants +2 on Diplomacy checks."
           }
+        },
+        {
+          "id": "synergy-handle-animal-ride",
+          "source": {
+            "type": "skillSynergy",
+            "ref": "handle-animal"
+          },
+          "when": {
+            "op": "gte",
+            "left": {
+              "kind": "skillRanks",
+              "id": "handle-animal"
+            },
+            "right": 5
+          },
+          "apply": {
+            "target": {
+              "kind": "skill",
+              "id": "ride"
+            },
+            "bonus": 2,
+            "bonusType": "untyped",
+            "note": "PHB 3.5 Table 4-5: 5 ranks in Handle Animal grants +2 on Ride checks."
+          }
+        },
+        {
+          "id": "synergy-knowledge-arcana-spellcraft",
+          "source": {
+            "type": "skillSynergy",
+            "ref": "knowledge-arcana"
+          },
+          "when": {
+            "op": "gte",
+            "left": {
+              "kind": "skillRanks",
+              "id": "knowledge-arcana"
+            },
+            "right": 5
+          },
+          "apply": {
+            "target": {
+              "kind": "skill",
+              "id": "spellcraft"
+            },
+            "bonus": 2,
+            "bonusType": "untyped",
+            "note": "PHB 3.5 Table 4-5: 5 ranks in Knowledge (Arcana) grants +2 on Spellcraft checks."
+          }
+        },
+        {
+          "id": "synergy-knowledge-local-gather-information",
+          "source": {
+            "type": "skillSynergy",
+            "ref": "knowledge-local"
+          },
+          "when": {
+            "op": "gte",
+            "left": {
+              "kind": "skillRanks",
+              "id": "knowledge-local"
+            },
+            "right": 5
+          },
+          "apply": {
+            "target": {
+              "kind": "skill",
+              "id": "gather-information"
+            },
+            "bonus": 2,
+            "bonusType": "untyped",
+            "note": "PHB 3.5 Table 4-5: 5 ranks in Knowledge (Local) grants +2 on Gather Information checks."
+          }
+        },
+        {
+          "id": "synergy-knowledge-nobility-and-royalty-diplomacy",
+          "source": {
+            "type": "skillSynergy",
+            "ref": "knowledge-nobility-and-royalty"
+          },
+          "when": {
+            "op": "gte",
+            "left": {
+              "kind": "skillRanks",
+              "id": "knowledge-nobility-and-royalty"
+            },
+            "right": 5
+          },
+          "apply": {
+            "target": {
+              "kind": "skill",
+              "id": "diplomacy"
+            },
+            "bonus": 2,
+            "bonusType": "untyped",
+            "note": "PHB 3.5 Table 4-5: 5 ranks in Knowledge (Nobility and Royalty) grants +2 on Diplomacy checks."
+          }
+        },
+        {
+          "id": "synergy-survival-knowledge-nature",
+          "source": {
+            "type": "skillSynergy",
+            "ref": "survival"
+          },
+          "when": {
+            "op": "gte",
+            "left": {
+              "kind": "skillRanks",
+              "id": "survival"
+            },
+            "right": 5
+          },
+          "apply": {
+            "target": {
+              "kind": "skill",
+              "id": "knowledge-nature"
+            },
+            "bonus": 2,
+            "bonusType": "untyped",
+            "note": "PHB 3.5 Table 4-5: 5 ranks in Survival grants +2 on Knowledge (Nature) checks."
+          }
         }
       ]
     },


### PR DESCRIPTION
## Summary
- add the remaining unconditional SRD 3.5 skill synergy pairs that the current engine can apply correctly
- lock the pack data update with an authenticity hash refresh
- add contracts-side dataset coverage plus engine regression coverage for the new synergy mappings

## Verification
- npm --workspace @dcb/contracts run test -- src/skillSynergyDataset.test.ts
- npm --workspace @dcb/engine run test -- src/engineSkillSynergyRules.test.ts
- npm run contracts
- npm run check:contract-fixtures

## Notes
- This PR intentionally limits itself to unconditional synergies that the current pipeline can represent without over-applying context-specific bonuses. Context-bound SRD synergies remain out of scope until their targeting semantics exist in the engine.