### PR TITLE
[P0] Add compute golden fixture for invalid normalized CharacterSpec input (issue #161)

### DIFF
--- a/packages/engine/src/__fixtures__/compute-contract-invalid-normalization.golden.json
+++ b/packages/engine/src/__fixtures__/compute-contract-invalid-normalization.golden.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": "0.1",
+  "validationIssues": [
+    {
+      "code": "SPEC_CLASS_LEVEL_INVALID",
+      "severity": "error",
+      "message": "class.level must be an integer >= 1.",
+      "path": "class.level"
+    },
+    {
+      "code": "NAME_REQUIRED",
+      "severity": "error",
+      "message": "Character name is required.",
+      "path": "meta.name"
+    }
+  ],
+  "assumptions": [
+    {
+      "code": "SPEC_CLASS_LEVEL_CLAMPED",
+      "message": "Class level was adjusted during normalization (set to 1).",
+      "path": "class.level",
+      "defaultUsed": 1
+    }
+  ]
+}

--- a/packages/engine/src/computeContractGoldenFixtures.test.ts
+++ b/packages/engine/src/computeContractGoldenFixtures.test.ts
@@ -1,0 +1,40 @@
+import {
+  compute,
+  context,
+  describe,
+  expect,
+  fs,
+  it
+} from "./engineTestSupport";
+
+const invalidNormalizationGoldenFixture = new URL(
+  "./__fixtures__/compute-contract-invalid-normalization.golden.json",
+  import.meta.url
+);
+
+describe("compute() golden fixtures", () => {
+  it("produces deterministic validation and assumption ordering for invalid normalized CharacterSpec input", () => {
+    const result = compute(
+      {
+        meta: { name: " ", rulesetId: "dnd35e", sourceIds: ["srd-35e-minimal"] },
+        raceId: "human",
+        class: { classId: "fighter", level: 1.9 },
+        abilities: { str: 16, dex: 12, con: 14, int: 10, wis: 10, cha: 8 },
+        skillRanks: { climb: 4, jump: 3, diplomacy: 0.5 },
+        featIds: ["power-attack"],
+        equipmentIds: ["longsword", "chainmail", "heavy-wooden-shield"]
+      },
+      { resolvedData: context.resolvedData, enabledPackIds: context.enabledPackIds }
+    );
+
+    const contractSlice = {
+      schemaVersion: result.schemaVersion,
+      validationIssues: result.validationIssues,
+      assumptions: result.assumptions
+    };
+
+    expect(contractSlice).toEqual(
+      JSON.parse(fs.readFileSync(invalidNormalizationGoldenFixture, "utf8")) as typeof contractSlice
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add an engine-side golden fixture for invalid-but-normalized CharacterSpec input
- lock deterministic ordering for schemaVersion, validationIssues, and assumptions
- keep the slice test-only without widening production contract semantics

## Verification
- npm --workspace @dcb/engine run test
- npm --workspace @dcb/contracts run test
- npm run check:contract-fixtures