### PR TITLE
[P1] Add skill-budget compute contract fixture (issue #96)

### DIFF
--- a/packages/contracts/src/skillBudgetContractFixture.test.ts
+++ b/packages/contracts/src/skillBudgetContractFixture.test.ts
@@ -1,0 +1,59 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { ContractFixtureSchema } from "@dcb/schema";
+
+describe("skill budget compute fixture", () => {
+  it("covers higher-level skill budget invariants for human fighter progression", () => {
+    const fixturePath = path.resolve(
+      process.cwd(),
+      "../../packs/srd-35e-minimal/contracts/human-fighter-3-skill-budget-compute.json"
+    );
+    const fixture = ContractFixtureSchema.parse(JSON.parse(fs.readFileSync(fixturePath, "utf8")));
+
+    expect("characterSpec" in fixture).toBe(true);
+
+    if (!("characterSpec" in fixture)) {
+      throw new Error("Expected skill-budget contract fixture to use the compute fixture shape");
+    }
+
+    expect(fixture.characterSpec).toMatchObject({
+      meta: {
+        name: "Aric III",
+        rulesetId: "dnd35e",
+        sourceIds: ["srd-35e-minimal"]
+      },
+      raceId: "human",
+      class: {
+        classId: "fighter",
+        level: 3
+      },
+      abilities: {
+        int: 12
+      },
+      skillRanks: {
+        climb: 6,
+        listen: 3
+      }
+    });
+
+    expect(fixture.contractClarifications).toMatchObject({
+      skillBudget:
+        "This fixture locks level-scaled skill budget totals plus class/cross-class spend invariants for compute(spec, rulepack)."
+    });
+
+    expect(fixture.expected.computeResultSubset).toMatchObject({
+      sheetViewModel: {
+        data: {
+          review: {
+            skillBudget: {
+              total: 24,
+              spent: 12,
+              remaining: 12
+            }
+          }
+        }
+      }
+    });
+  });
+});

--- a/packs/srd-35e-minimal/contracts/human-fighter-3-skill-budget-compute.json
+++ b/packs/srd-35e-minimal/contracts/human-fighter-3-skill-budget-compute.json
@@ -1,0 +1,60 @@
+{
+  "enabledPacks": [
+    "srd-35e-minimal"
+  ],
+  "characterSpec": {
+    "meta": {
+      "name": "Aric III",
+      "rulesetId": "dnd35e",
+      "sourceIds": ["srd-35e-minimal"]
+    },
+    "raceId": "human",
+    "class": {
+      "classId": "fighter",
+      "level": 3
+    },
+    "abilities": {
+      "str": 16,
+      "dex": 12,
+      "con": 14,
+      "int": 12,
+      "wis": 10,
+      "cha": 8
+    },
+    "skillRanks": {
+      "climb": 6,
+      "listen": 3
+    },
+    "featIds": [
+      "power-attack"
+    ],
+    "equipmentIds": [
+      "longsword",
+      "chainmail",
+      "heavy-wooden-shield"
+    ]
+  },
+  "contractClarifications": {
+    "skillBudget": "This fixture locks level-scaled skill budget totals plus class/cross-class spend invariants for compute(spec, rulepack)."
+  },
+  "expected": {
+    "validationIssueCodes": [],
+    "computeResultSubset": {
+      "schemaVersion": "0.1",
+      "sheetViewModel": {
+        "schemaVersion": "0.1",
+        "data": {
+          "review": {
+            "skillBudget": {
+              "total": 24,
+              "spent": 12,
+              "remaining": 12
+            }
+          }
+        }
+      },
+      "validationIssues": [],
+      "assumptions": []
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a higher-level compute contract fixture for a human fighter skill-budget scenario
- lock total, spent, and remaining skill-budget totals under compute(spec, rulepack)
- keep the slice on contract/test coverage only without production engine changes

## Verification
- npx vitest run in packages/contracts
- npx vitest run in packages/engine
- npm run check:contract-fixtures