### PR TITLE
feat(datapack): pre-index conditional skill modifiers

### DIFF
--- a/packages/datapack/src/core.ts
+++ b/packages/datapack/src/core.ts
@@ -19,10 +19,35 @@ export interface EntitySourceMetadata {
 
 export type ResolvedEntity = Entity & { _source: EntitySourceMetadata };
 
+export type ResolvedConditionalModifierPredicate =
+  | { op: "gte"; left: { kind: "skillRanks"; id: string }; right: number }
+  | { op: "and" | "or"; args: ResolvedConditionalModifierPredicate[] }
+  | { op: "hasFeat"; id: string }
+  | { op: "hasFeature"; id: string }
+  | { op: "isClassSkill"; target: { kind: "skill"; id: string } };
+
+export interface ResolvedConditionalSkillModifier {
+  id: string;
+  sourceType: string;
+  source: {
+    packId: string;
+    entityType: string;
+    entityId: string;
+  };
+  when: ResolvedConditionalModifierPredicate;
+  apply: {
+    targetSkillId: string;
+    bonus: number;
+    bonusType?: string;
+    note?: string;
+  };
+}
+
 export interface ResolvedPackSet {
   orderedPackIds: string[];
   manifests: Manifest[];
   entities: Record<string, Record<string, ResolvedEntity>>;
+  conditionalSkillModifiers?: ResolvedConditionalSkillModifier[];
   flow: Flow;
   pageSchemas: Record<string, Page>;
   locales: Record<string, PackLocale>;
@@ -125,6 +150,113 @@ function rotr(value: number, bits: number): number {
   return (value >>> bits) | (value << (32 - bits));
 }
 
+function normalizeModifierId(id: string): string {
+  return id.trim().toLowerCase();
+}
+
+function getEntityDataRecord(entity: ResolvedEntity): Record<string, unknown> {
+  if (!entity.data || typeof entity.data !== "object" || Array.isArray(entity.data)) return {};
+  return entity.data as Record<string, unknown>;
+}
+
+function parseConditionalModifierPredicate(value: unknown): ResolvedConditionalModifierPredicate | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  const op = String(record.op ?? "").trim().toLowerCase();
+
+  if (op === "gte") {
+    const leftRaw = record.left;
+    const rightRaw = Number(record.right);
+    if (!leftRaw || typeof leftRaw !== "object" || Array.isArray(leftRaw) || !Number.isFinite(rightRaw)) return undefined;
+    const leftRecord = leftRaw as Record<string, unknown>;
+    if (String(leftRecord.kind ?? "").trim().toLowerCase() !== "skillranks") return undefined;
+    const skillId = normalizeModifierId(String(leftRecord.id ?? ""));
+    if (!skillId) return undefined;
+    return { op: "gte", left: { kind: "skillRanks", id: skillId }, right: rightRaw };
+  }
+
+  if (op === "and" || op === "or") {
+    if (!Array.isArray(record.args)) return undefined;
+    const parsedArgs = record.args.map((entry) => parseConditionalModifierPredicate(entry));
+    if (parsedArgs.length === 0 || parsedArgs.some((entry) => entry === undefined)) return undefined;
+    return { op, args: parsedArgs as ResolvedConditionalModifierPredicate[] };
+  }
+
+  if (op === "hasfeat") {
+    const featId = normalizeModifierId(String(record.id ?? ""));
+    return featId ? { op: "hasFeat", id: featId } : undefined;
+  }
+
+  if (op === "hasfeature") {
+    const featureId = normalizeModifierId(String(record.id ?? ""));
+    return featureId ? { op: "hasFeature", id: featureId } : undefined;
+  }
+
+  if (op === "isclassskill" || op === "isproficient") {
+    const targetRaw = record.target;
+    if (!targetRaw || typeof targetRaw !== "object" || Array.isArray(targetRaw)) return undefined;
+    const target = targetRaw as Record<string, unknown>;
+    if (String(target.kind ?? "").trim().toLowerCase() !== "skill") return undefined;
+    const skillId = normalizeModifierId(String(target.id ?? ""));
+    return skillId ? { op: "isClassSkill", target: { kind: "skill", id: skillId } } : undefined;
+  }
+
+  return undefined;
+}
+
+function buildConditionalSkillModifierIndex(
+  entities: Record<string, Record<string, ResolvedEntity>>
+): ResolvedConditionalSkillModifier[] {
+  const index: ResolvedConditionalSkillModifier[] = [];
+
+  for (const entityBucket of Object.values(entities)) {
+    for (const entity of Object.values(entityBucket)) {
+      const conditionalModifiers = getEntityDataRecord(entity).conditionalModifiers;
+      if (!Array.isArray(conditionalModifiers)) continue;
+
+      for (const entry of conditionalModifiers) {
+        if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue;
+        const record = entry as Record<string, unknown>;
+        const applyRaw = record.apply as Record<string, unknown> | undefined;
+        const targetRaw = applyRaw?.target as Record<string, unknown> | undefined;
+        const when = parseConditionalModifierPredicate(record.when);
+        const targetKind = String(targetRaw?.kind ?? "").trim().toLowerCase();
+        const targetSkillId = normalizeModifierId(String(targetRaw?.id ?? ""));
+        const bonus = Number(applyRaw?.bonus ?? 0);
+
+        if (!String(record.id ?? "").trim() || !when || targetKind !== "skill" || !targetSkillId || !Number.isFinite(bonus)) {
+          continue;
+        }
+
+        index.push({
+          id: String(record.id).trim(),
+          sourceType: String((record.source as Record<string, unknown> | undefined)?.type ?? "misc").trim(),
+          source: {
+            packId: entity._source.packId,
+            entityType: entity.entityType,
+            entityId: entity.id
+          },
+          when,
+          apply: {
+            targetSkillId,
+            bonus,
+            bonusType: typeof applyRaw?.bonusType === "string" && applyRaw.bonusType.trim() ? applyRaw.bonusType.trim() : undefined,
+            note: typeof applyRaw?.note === "string" && applyRaw.note.trim() ? applyRaw.note.trim() : undefined
+          }
+        });
+      }
+    }
+  }
+
+  index.sort((left, right) =>
+    left.source.packId.localeCompare(right.source.packId)
+    || left.source.entityType.localeCompare(right.source.entityType)
+    || left.source.entityId.localeCompare(right.source.entityId)
+    || left.id.localeCompare(right.id)
+  );
+
+  return index;
+}
 
 function getDefined(values: ReadonlyArray<number> | Uint32Array, index: number, label: string): number {
   const value = values[index];
@@ -306,6 +438,7 @@ export function resolveLoadedPacks(loaded: LoadedPack[], enabledPackIds: string[
     }
   }
 
+  const conditionalSkillModifiers = buildConditionalSkillModifierIndex(entities);
   const fingerprintPayload = {
     orderedPackIds: sorted.map((p) => p.manifest.id),
     entities,
@@ -319,6 +452,7 @@ export function resolveLoadedPacks(loaded: LoadedPack[], enabledPackIds: string[
     orderedPackIds: sorted.map((p) => p.manifest.id),
     manifests: sorted.map((p) => p.manifest),
     entities,
+    conditionalSkillModifiers,
     flow,
     pageSchemas,
     locales,

--- a/packages/datapack/src/datapack.test.ts
+++ b/packages/datapack/src/datapack.test.ts
@@ -484,4 +484,77 @@ describe("resolvePackSet", () => {
     expect(resolved.entities.rules?.shared?._source.packId).toBe("override");
     expect(resolved.entities.rules?.shared?._source.entityId).toBe("shared");
   });
+
+  it("builds conditional skill modifier indexes from patched resolved entities", () => {
+    const base = makePack("base", 1);
+    base.entities.rules = [{
+      id: "shared-conditional-rule",
+      name: "Shared Conditional Rule",
+      entityType: "rules",
+      summary: "Shared conditional rule",
+      description: "Shared conditional rule desc",
+      portraitUrl: "assets/rules/shared-conditional-rule-portrait.png",
+      iconUrl: "assets/icons/rules/shared-conditional-rule.png",
+      effects: [],
+      data: {
+        conditionalModifiers: [{
+          id: "climb-to-balance",
+          source: { type: "skillSynergy", ref: "climb" },
+          when: {
+            op: "gte",
+            left: { kind: "skillRanks", id: "climb" },
+            right: 5
+          },
+          apply: {
+            target: { kind: "skill", id: "balance" },
+            bonus: 2
+          }
+        }]
+      }
+    }];
+
+    const override = makePack("override", 2, ["base"]);
+    override.patches = [{
+      op: "mergeEntity",
+      entityType: "rules",
+      id: "shared-conditional-rule",
+      value: {
+        data: {
+          conditionalModifiers: [{
+            id: "climb-to-balance",
+            source: { type: "skillSynergy", ref: "climb" },
+            when: {
+              op: "gte",
+              left: { kind: "skillRanks", id: "climb" },
+              right: 5
+            },
+            apply: {
+              target: { kind: "skill", id: "balance" },
+              bonus: 4,
+              note: "patched"
+            }
+          }]
+        }
+      }
+    }];
+
+    const resolved = resolveLoadedPacks([base, override], ["override"]);
+
+    expect(resolved.conditionalSkillModifiers).toEqual([
+      expect.objectContaining({
+        id: "climb-to-balance",
+        sourceType: "skillSynergy",
+        source: {
+          packId: "override",
+          entityType: "rules",
+          entityId: "shared-conditional-rule"
+        },
+        apply: expect.objectContaining({
+          targetSkillId: "balance",
+          bonus: 4,
+          note: "patched"
+        })
+      })
+    ]);
+  });
 });

--- a/packages/engine/src/engineConditionalModifiers.test.ts
+++ b/packages/engine/src/engineConditionalModifiers.test.ts
@@ -14,6 +14,113 @@ import {
 } from "./engineTestSupport";
 
 describe("engine determinism", () => {
+  it("consumes pre-indexed conditional modifiers even when raw entity payloads are absent", () => {
+    const indexedConditionalPack: LoadedPack = {
+      manifest: { id: "indexed-conditional-pack", name: "IndexedConditionalPack", version: "1.0.0", priority: 5, dependencies: [] },
+      entities: {
+        races: [{
+          id: "human",
+          name: "Human",
+          entityType: "races",
+          summary: "Human",
+          description: "Human",
+          portraitUrl: null,
+          iconUrl: null,
+          effects: [],
+          data: {
+            size: "medium",
+            baseSpeed: 30,
+            abilityModifiers: {},
+            vision: { lowLight: false, darkvisionFeet: 0 },
+            automaticLanguages: ["Common"],
+            bonusLanguages: ["Any"],
+            favoredClass: "any",
+            racialTraits: []
+          }
+        }],
+        classes: [{
+          id: "fighter",
+          name: "Fighter",
+          entityType: "classes",
+          summary: "Fighter",
+          description: "Fighter",
+          portraitUrl: null,
+          iconUrl: null,
+          effects: [],
+          data: { hitDie: 10, skillPointsPerLevel: 2, classSkills: ["climb"] }
+        }],
+        feats: [],
+        items: [],
+        skills: [
+          { id: "climb", name: "Climb", entityType: "skills", summary: "Climb", description: "Climb", portraitUrl: null, iconUrl: null, data: { ability: "str", armorCheckPenaltyApplies: true } },
+          { id: "balance", name: "Balance", entityType: "skills", summary: "Balance", description: "Balance", portraitUrl: null, iconUrl: null, data: { ability: "dex", armorCheckPenaltyApplies: true } }
+        ],
+        rules: [{
+          id: "base-ac",
+          name: "Base AC",
+          entityType: "rules",
+          summary: "Base AC",
+          description: "Base AC",
+          portraitUrl: null,
+          iconUrl: null,
+          effects: [{ kind: "set", targetPath: "stats.ac", value: { const: 10 } }]
+        }, {
+          id: "indexed-conditional",
+          name: "Indexed Conditional",
+          entityType: "rules",
+          summary: "Indexed Conditional",
+          description: "Should use the resolved conditional modifier index",
+          portraitUrl: null,
+          iconUrl: null,
+          effects: [],
+          data: {
+            conditionalModifiers: [{
+              id: "climb-to-balance",
+              source: { type: "skillSynergy", ref: "climb" },
+              when: {
+                op: "gte",
+                left: { kind: "skillRanks", id: "climb" },
+                right: 5
+              },
+              apply: {
+                target: { kind: "skill", id: "balance" },
+                bonus: 2
+              }
+            }]
+          }
+        }]
+      },
+      flow: {
+        steps: [
+          { id: "name", kind: "metadata", label: "Name", source: { type: "manual" } },
+          { id: "abilities", kind: "abilities", label: "Ability Scores", source: { type: "manual" } },
+          { id: "race", kind: "race", label: "Race", source: { type: "entityType", entityType: "races", limit: 1 } },
+          { id: "class", kind: "class", label: "Class", source: { type: "entityType", entityType: "classes", limit: 1 } }
+        ]
+      },
+      patches: [],
+      packPath: "indexed-conditional-pack"
+    };
+    const resolvedData = resolveLoadedPacks([makePack("base", 1), indexedConditionalPack], ["indexed-conditional-pack"]);
+    const indexedRule = resolvedData.entities.rules?.["indexed-conditional"];
+    if (!indexedRule) throw new Error("Expected indexed conditional rule to resolve");
+    indexedRule.data = {};
+
+    const indexedConditionalContext = {
+      enabledPackIds: ["indexed-conditional-pack"],
+      resolvedData
+    };
+
+    let state = applyChoice(initialState, "name", "IndexedConditional");
+    state = applyChoice(state, "abilities", { str: 12, dex: 12, con: 10, int: 10, wis: 10, cha: 10 });
+    state = applyChoice(state, "race", "human");
+    state = applyChoice(state, "class", "fighter");
+    state = applyChoice(state, "skills", { climb: 5 }, indexedConditionalContext);
+
+    const sheet = finalizeCharacter(state, indexedConditionalContext);
+    expect(sheet.skills.balance?.miscBonus).toBe(2);
+  });
+
   it("treats malformed composite conditional predicates as invalid and applies no bonus", () => {
     const malformedConditionalPack: LoadedPack = {
       manifest: { id: "malformed-conditional-pack", name: "MalformedConditionalPack", version: "1.0.0", priority: 5, dependencies: [] },
@@ -116,5 +223,120 @@ describe("engine determinism", () => {
 
     const sheet = finalizeCharacter(state, malformedContext);
     expect(sheet.skills.balance?.miscBonus).toBe(0);
+  });
+
+  it("keeps feat-sourced conditional modifiers gated by selection when using the resolved index", () => {
+    const indexedFeatPack: LoadedPack = {
+      manifest: { id: "indexed-feat-pack", name: "IndexedFeatPack", version: "1.0.0", priority: 5, dependencies: [] },
+      entities: {
+        races: [{
+          id: "human",
+          name: "Human",
+          entityType: "races",
+          summary: "Human",
+          description: "Human",
+          portraitUrl: null,
+          iconUrl: null,
+          effects: [],
+          data: {
+            size: "medium",
+            baseSpeed: 30,
+            abilityModifiers: {},
+            vision: { lowLight: false, darkvisionFeet: 0 },
+            automaticLanguages: ["Common"],
+            bonusLanguages: ["Any"],
+            favoredClass: "any",
+            racialTraits: []
+          }
+        }],
+        classes: [{
+          id: "fighter",
+          name: "Fighter",
+          entityType: "classes",
+          summary: "Fighter",
+          description: "Fighter",
+          portraitUrl: null,
+          iconUrl: null,
+          effects: [],
+          data: { hitDie: 10, skillPointsPerLevel: 2, classSkills: ["climb"] }
+        }],
+        feats: [{
+          id: "acrobatic",
+          name: "Acrobatic",
+          entityType: "feats",
+          summary: "Acrobatic",
+          description: "Acrobatic",
+          portraitUrl: null,
+          iconUrl: null,
+          effects: [],
+          data: {
+            conditionalModifiers: [{
+              id: "acrobatic-balance",
+              source: { type: "feat", ref: "acrobatic" },
+              when: {
+                op: "gte",
+                left: { kind: "skillRanks", id: "climb" },
+                right: 1
+              },
+              apply: {
+                target: { kind: "skill", id: "balance" },
+                bonus: 2
+              }
+            }]
+          }
+        }],
+        items: [],
+        skills: [
+          { id: "climb", name: "Climb", entityType: "skills", summary: "Climb", description: "Climb", portraitUrl: null, iconUrl: null, data: { ability: "str", armorCheckPenaltyApplies: true } },
+          { id: "balance", name: "Balance", entityType: "skills", summary: "Balance", description: "Balance", portraitUrl: null, iconUrl: null, data: { ability: "dex", armorCheckPenaltyApplies: true } }
+        ],
+        rules: [{
+          id: "base-ac",
+          name: "Base AC",
+          entityType: "rules",
+          summary: "Base AC",
+          description: "Base AC",
+          portraitUrl: null,
+          iconUrl: null,
+          effects: [{ kind: "set", targetPath: "stats.ac", value: { const: 10 } }]
+        }]
+      },
+      flow: {
+        steps: [
+          { id: "name", kind: "metadata", label: "Name", source: { type: "manual" } },
+          { id: "abilities", kind: "abilities", label: "Ability Scores", source: { type: "manual" } },
+          { id: "race", kind: "race", label: "Race", source: { type: "entityType", entityType: "races", limit: 1 } },
+          { id: "class", kind: "class", label: "Class", source: { type: "entityType", entityType: "classes", limit: 1 } },
+          { id: "feat", kind: "feat", label: "Feat", source: { type: "entityType", entityType: "feats", limit: 1 } }
+        ]
+      },
+      patches: [],
+      packPath: "indexed-feat-pack"
+    };
+    const resolvedData = resolveLoadedPacks([makePack("base", 1), indexedFeatPack], ["indexed-feat-pack"]);
+    const indexedFeat = resolvedData.entities.feats?.acrobatic;
+    if (!indexedFeat) throw new Error("Expected indexed feat to resolve");
+    indexedFeat.data = {};
+
+    const indexedFeatContext = {
+      enabledPackIds: ["indexed-feat-pack"],
+      resolvedData
+    };
+
+    let unselectedState = applyChoice(initialState, "name", "UnselectedFeat");
+    unselectedState = applyChoice(unselectedState, "abilities", { str: 12, dex: 12, con: 10, int: 10, wis: 10, cha: 10 });
+    unselectedState = applyChoice(unselectedState, "race", "human");
+    unselectedState = applyChoice(unselectedState, "class", "fighter");
+    unselectedState = applyChoice(unselectedState, "skills", { climb: 1 }, indexedFeatContext);
+
+    let selectedState = applyChoice(initialState, "name", "SelectedFeat");
+    selectedState = applyChoice(selectedState, "abilities", { str: 12, dex: 12, con: 10, int: 10, wis: 10, cha: 10 });
+    selectedState = applyChoice(selectedState, "race", "human");
+    selectedState = applyChoice(selectedState, "class", "fighter");
+    selectedState = applyChoice(selectedState, "feat", "acrobatic");
+    selectedState = applyChoice(selectedState, "skills", { climb: 1 }, indexedFeatContext);
+
+    expect(finalizeCharacter(unselectedState, indexedFeatContext).skills.balance?.miscBonus).toBe(0);
+    expect(finalizeCharacter(selectedState, indexedFeatContext).skills.balance?.miscBonus).toBe(2);
   });
 });

--- a/packages/engine/src/legacyRuntimeRuleSurface.ts
+++ b/packages/engine/src/legacyRuntimeRuleSurface.ts
@@ -2,7 +2,6 @@ import type { CharacterState } from "./characterSpec";
 import type { EngineContext, SkillMiscBreakdownEntry, UnresolvedRule } from "./legacyRuntimeTypes";
 import {
   evaluateConditionalModifierPredicate,
-  parseConditionalSkillModifiers,
   type ConditionalPredicateEvaluationContext
 } from "./legacyRuntimeConditionalModifiers";
 import { getEntityDataRecord, parseDeferredMechanics } from "./legacyRuntimeEntityData";
@@ -24,9 +23,9 @@ export function buildConditionalSkillBonusData(
   const selectedFeatureIds = getSelectedFeatureIds(state, context);
   const classSkillIds = getClassSkills(state, context);
   const skillRanks = getDerivedSkillRanks(state, context);
-  const entities = [...Object.values(context.resolvedData.entities.rules ?? {}), ...getSelectedEntities(state, context)]
-    .filter((entity) => Array.isArray(getEntityDataRecord(entity).conditionalModifiers));
-  const seenEntities = new Set<string>();
+  const activeEntityKeys = new Set(
+    getSelectedEntities(state, context).map((entity) => `${entity._source.packId}:${entity.entityType}:${entity.id}`)
+  );
   const evaluationContext: ConditionalPredicateEvaluationContext = {
     skillRanks,
     selectedFeatIds,
@@ -34,23 +33,19 @@ export function buildConditionalSkillBonusData(
     classSkillIds
   };
 
-  for (const entity of entities) {
-    const entityKey = `${entity._source.packId}:${entity.entityType}:${entity.id}`;
-    if (seenEntities.has(entityKey)) continue;
-    seenEntities.add(entityKey);
-
-    for (const modifier of parseConditionalSkillModifiers(getEntityDataRecord(entity).conditionalModifiers)) {
-      if (!evaluateConditionalModifierPredicate(modifier.when, evaluationContext)) continue;
-      const skillId = modifier.apply.targetSkillId;
-      totals[skillId] = (totals[skillId] ?? 0) + modifier.apply.bonus;
-      (breakdown[skillId] ??= []).push({
-        id: modifier.id,
-        sourceType: modifier.sourceType,
-        bonus: modifier.apply.bonus,
-        ...(modifier.apply.bonusType ? { bonusType: modifier.apply.bonusType } : {}),
-        ...(modifier.apply.note ? { note: modifier.apply.note } : {})
-      });
-    }
+  for (const modifier of context.resolvedData.conditionalSkillModifiers ?? []) {
+    const sourceKey = `${modifier.source.packId}:${modifier.source.entityType}:${modifier.source.entityId}`;
+    if (modifier.source.entityType !== "rules" && !activeEntityKeys.has(sourceKey)) continue;
+    if (!evaluateConditionalModifierPredicate(modifier.when, evaluationContext)) continue;
+    const skillId = modifier.apply.targetSkillId;
+    totals[skillId] = (totals[skillId] ?? 0) + modifier.apply.bonus;
+    (breakdown[skillId] ??= []).push({
+      id: modifier.id,
+      sourceType: modifier.sourceType,
+      bonus: modifier.apply.bonus,
+      ...(modifier.apply.bonusType ? { bonusType: modifier.apply.bonusType } : {}),
+      ...(modifier.apply.note ? { note: modifier.apply.note } : {})
+    });
   }
 
   return { totals, breakdown };


### PR DESCRIPTION
## Summary
- pre-index resolved conditional skill modifiers during datapack resolution after patch application
- switch the legacy engine rule surface to consume the resolved conditional index instead of rescanning raw entity payloads
- add regression coverage for patched indexes, raw-payload-free consumption, and feat selection gating

## Verification
- npm --workspace @dcb/datapack run test
- npm --workspace @dcb/engine run test
- npm run typecheck

Closes #154