### PR TITLE
docs(engine): consolidate engine-refactor architecture truth

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,42 +1,81 @@
 # Architecture
 
-## Module/Data Flow
+This repository is moving off the old monolithic wizard-plus-engine shape and onto the `engine-refactor` integration line. The target is a contract-first frontend/backend split: the frontend owns rendering and interaction, while the engine owns rules evaluation and returns authoritative build feedback.
+
+## Canonical Refactor Docs
+
+These files are the current source of truth for the refactor:
+
+- `docs/architecture.md`
+- `docs/data/ENGINE_RUNTIME_ARCHITECTURE.md`
+- `docs/engineering/ENGINE_REFACTOR_STATUS.md`
+
+Files under `docs/plans/` remain valuable, but they are historical design and implementation records. They should not carry the latest architecture truth by themselves.
+
+## System Boundary
+
+The target system boundary is:
 
 ```text
-[packs/* JSON] -> [packages/datapack]
-                  - validate manifest/entities/flow
-                  - dependency topo sort + priority
-                  - merge + patch + fingerprint
-                          |
-                          v
-                   resolved pack set
-                          |
-                          v
-                    [packages/engine]
-         listChoices/applyChoice/validate/finalize
-         - deterministic DSL interpreter
-         - prerequisites + exclusivity
-         - derived stats + provenance
-                          |
-                          v
-                     [apps/web]
-             thin wizard UI + JSON export + HTML sheet
+[authored rules/packs]
+        |
+        v
+[normalization / compiler]
+        |
+        v
+[engine backend / domain service]
+        |
+        v
+[frontend client]
 ```
+
+Important consequences:
+
+- Rules content remains the canonical source of rule meaning.
+- The engine executes compiled or normalized rules data, not raw UI state.
+- The frontend owns local interaction mechanics such as clicks, draft form behavior, and presentation.
+- The engine should behave like a backend-style domain service even if transport and deployment are introduced later.
+
+## Contract-First Flow
+
+The current top-down direction is:
+
+1. The user chooses a `RulesContext`.
+2. The engine resolves a fixed flow for that `RulesContext`.
+3. The frontend gathers durable user input for that flow.
+4. The engine evaluates the submitted snapshot and returns authoritative build feedback.
+5. Terminal or explicit projection requests may additionally return a full user-data sheet.
+
+This keeps the frontend out of rules truth while still letting it own rendering and UX.
+
+## Responsibilities
+
+### Rules / compiler layer
+
+- author and organize rules content
+- normalize or compile it into an engine-executable form
+- keep authored source data separate from runtime request data
+
+### Engine layer
+
+- accept rule-universe input plus user-source input
+- resolve flow after rules are selected
+- evaluate legality, progression, and derived build state
+- return authoritative builder-facing outputs
+
+### Frontend layer
+
+- render the flow returned by the engine
+- manage interaction and local draft behavior
+- submit durable user input, not raw UI events
+- present returned build status, issues, and projections
 
 ## Determinism
-- Engine APIs are pure and deterministic.
-- Character `state` stores only user selections, not derived stats.
-- Derived stats are recomputed on finalize from resolved pack data.
 
-## Provenance
-Each applied effect emits a provenance record:
+- Engine evaluation should stay deterministic for the same rules context and input snapshot.
+- The frontend should not recompute rules truth on its own.
+- Flow status, legality, and derived build outputs come from the engine contract, not from UI heuristics.
 
-```json
-{
-  "targetPath": "stats.ac",
-  "delta": 2,
-  "source": { "packId": "srd-35e-minimal", "entityId": "heavy-wooden-shield" }
-}
-```
+## Provenance And Explanation
 
-This powers “why is this number this number?” in the review UI.
+The engine should continue to expose explanation/provenance surfaces where useful so the frontend can answer “why is this result what it is?” without re-implementing rule logic in the client.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,6 +2,8 @@
 
 This repository is moving off the old monolithic wizard-plus-engine shape and onto the `engine-refactor` integration line. The target is a contract-first frontend/backend split: the frontend owns rendering and interaction, while the engine owns rules evaluation and returns authoritative build feedback.
 
+The refactor is now being driven top-down from product invariants, not bottom-up from the old executor model. The architecture must first define what survives rules changes, what the user is building, and what the engine owes its callers before it freezes any internal loop, IR, or registry shape.
+
 ## Canonical Refactor Docs
 
 These files are the current source of truth for the refactor:
@@ -36,17 +38,44 @@ Important consequences:
 - The frontend owns local interaction mechanics such as clicks, draft form behavior, and presentation.
 - The engine should behave like a backend-style domain service even if transport and deployment are introduced later.
 
-## Contract-First Flow
+## Top-Level Product Invariant
 
-The current top-down direction is:
+For MVP, the hardest invariant is the relationship between the selected rule universe and the current build:
+
+- the user first chooses a `RulesContext`
+- the engine compiles or normalizes that rule universe
+- the engine resolves a fixed flow for that context
+- the user then builds inside that context
+- if the `RulesContext` changes, MVP resets the current build and starts fresh
+
+This means MVP does not yet preserve cross-ruleset build progress. That later preservation and cleanup story is important, but it should extend the architecture rather than distort the initial contract.
+
+## Core Product Objects
+
+The architecture should be understood in terms of these first-class objects:
+
+- `RulesContext`
+  The selected rule universe: ruleset, enabled packs, optional rules, bans, overrides, and similar choices.
+- `CompiledRulesContext`
+  The normalized or compiled executable form of that rule universe.
+- `FlowDescriptor`
+  The fixed builder flow derived from the chosen rules context.
+- `CommittedBuildState`
+  The durable user-owned build state under the current rules context. For MVP, this contains committed user data only. Temporary edits stay in the frontend until the user commits a step.
+- `EvaluationResult`
+  The authoritative engine response for the current committed build state.
+
+## MVP Lifecycle
+
+The top-down MVP flow is:
 
 1. The user chooses a `RulesContext`.
-2. The engine resolves a fixed flow for that `RulesContext`.
-3. The frontend gathers durable user input for that flow.
-4. The engine evaluates the submitted snapshot and returns authoritative build feedback.
-5. Terminal or explicit projection requests may additionally return a full user-data sheet.
-
-This keeps the frontend out of rules truth while still letting it own rendering and UX.
+2. The engine compiles or normalizes that rules context.
+3. The engine resolves a fixed `FlowDescriptor`.
+4. The frontend gathers temporary edits locally while the user works through a step.
+5. When the user commits a step, such as clicking `Next`, the frontend submits the current `CommittedBuildState`.
+6. The engine evaluates that committed state and returns the updated authoritative result.
+7. If the `RulesContext` changes, the current `CommittedBuildState` is discarded and the flow starts over.
 
 ## Responsibilities
 
@@ -54,28 +83,47 @@ This keeps the frontend out of rules truth while still letting it own rendering 
 
 - author and organize rules content
 - normalize or compile it into an engine-executable form
-- keep authored source data separate from runtime request data
+- keep authored source data separate from build state
 
 ### Engine layer
 
-- accept rule-universe input plus user-source input
+- accept the selected rule universe and committed build state
 - resolve flow after rules are selected
 - evaluate legality, progression, and derived build state
-- return authoritative builder-facing outputs
+- return authoritative builder-facing outputs and explanations
 
 ### Frontend layer
 
 - render the flow returned by the engine
-- manage interaction and local draft behavior
-- submit durable user input, not raw UI events
-- present returned build status, issues, and projections
+- manage interaction and temporary local edits
+- submit committed build state, not raw UI events
+- present returned build status, issues, explanations, and projections
 
 ## Determinism
 
-- Engine evaluation should stay deterministic for the same rules context and input snapshot.
+- Engine evaluation should stay deterministic for the same rules context and committed build state.
 - The frontend should not recompute rules truth on its own.
 - Flow status, legality, and derived build outputs come from the engine contract, not from UI heuristics.
 
-## Provenance And Explanation
+## Engine Obligations
 
-The engine should continue to expose explanation/provenance surfaces where useful so the frontend can answer “why is this result what it is?” without re-implementing rule logic in the client.
+For MVP, the engine must be able to:
+
+- return the flow after rules selection
+- return legality and completion status for the current flow
+- return issues, unresolved state, assumptions, and blocking feedback where applicable
+- return explanation and provenance surfaces so the frontend can answer why a result exists
+- return authoritative builder-facing summaries during the flow
+- return the full user-data sheet at the terminal step
+
+## Deferred Internal Decisions
+
+These are intentionally downstream of the product contract:
+
+- whether the runtime executor is fixed-point or something simpler
+- whether `RuntimeRequest = { changes[] }` survives in any public or internal form
+- whether capability behavior is modeled as `capability + op + args` or something more domain-shaped
+- the final ownership and merge rules for cross-capability facts, resources, and entities
+- the final transport/API shape and any long-lived backend persistence
+
+Those details matter, but they should follow from the top-level product objects and guarantees above rather than define them.

--- a/docs/data/ENGINE_RUNTIME_ARCHITECTURE.md
+++ b/docs/data/ENGINE_RUNTIME_ARCHITECTURE.md
@@ -1,249 +1,157 @@
 # Engine Runtime Architecture
 
-This document defines the stable contract boundary for the engine runtime architecture approved under issue `#233`.
+This document defines the current runtime-contract direction on the `engine-refactor` integration branch. It supersedes branch-era plan text that lived only in `docs/plans/`.
 
-## Four Representations
+## Purpose
 
-The engine redesign separates four representations:
+The engine refactor is moving toward a backend-style domain service with a contract-first boundary:
+
+- rules data stays authoritative
+- the engine owns evaluation and flow resolution
+- the frontend owns rendering and interaction
+- API transport and deployment can be introduced later without changing the core contract
+
+## Canonical Runtime Boundary
+
+The runtime boundary now separates five things:
 
 1. Authored source
-   - Human-maintained pack data that stays close to sourcebook structure.
-   - Canonical home for text, tables, and pack-authored semantics.
 2. Normalized pack IR
-   - Compiler-owned intermediate representation.
-   - Resolves links, IDs, and capability-owned fragments before final bundle emission.
 3. Compiled runtime bundle
-   - Static engine execution input.
-   - Character-agnostic, cacheable, and reusable across requests.
-4. RuntimeRequest
-   - Per-character normalized change request.
-   - Carries normalized change records that seed runtime change propagation.
+4. `RulesContext`
+5. per-build request snapshot
 
-The engine executes `CompiledRuntimeBundle + RuntimeRequest`. It does not execute raw authored entity fields, and it does not keep per-character copies of a rules bundle. The architectural stance is change-driven: the runtime holds normalized changes, propagates them deterministically, and converges to fixed point. It is not a UI flow runner, and fixed-point convergence is not an implementation detail.
+The engine should execute a compiled bundle against rule-universe input plus per-build user input. It should not execute raw authored entity fields, and it should not depend on frontend click history or transient UI state.
+
+## RulesContext
+
+`RulesContext` is the rule-universe input. Typical examples include:
+
+- selected ruleset or edition
+- enabled packs or sources
+- optional-rule toggles
+- bans, overrides, or house-rule profiles
+
+`RulesContext` must be chosen before the engine resolves flow.
+
+## Flow Resolution
+
+The current direction is to treat flow as engine-owned output derived from `RulesContext`.
+
+At the contract level:
+
+- the frontend selects a `RulesContext`
+- the engine resolves a flow descriptor for that context
+- that flow is fixed for the chosen `RulesContext` in MVP
+- flow nodes use opaque IDs defined by the resolved flow, not engine-reserved domain nouns
+
+The frontend still owns presentation, layout, and component behavior, but it should not invent or reorder the authoritative flow on its own.
+
+## Request Snapshot
+
+After flow resolution, the frontend submits a durable request snapshot for evaluation.
+
+Important boundary rules:
+
+- submit durable user state, not raw UI events
+- clicks, hover state, open panels, and stepper mechanics stay in the frontend
+- the request remains generic and should avoid hardcoded D&D-specific engine primitives
+- the request-side vocabulary may continue to use generic concepts such as:
+  - input
+  - selection
+  - acquire
+
+Older branch-era docs may refer to the request half as `RuntimeRequest`. That historical naming is still useful, but it is no longer sufficient by itself to describe the whole runtime source model.
+
+## Two Main Contract Surfaces
+
+The current contract direction is best understood as two surfaces:
+
+### `resolveFlow(rulesContext)`
+
+Returns the fixed flow descriptor for the chosen `RulesContext`.
+
+That descriptor should define:
+
+- opaque node IDs
+- ordering
+- the structure needed for the frontend to render and navigate the builder
+
+### `evaluate(rulesContext, requestSnapshot)`
+
+Recomputes the current authoritative build result for the submitted source state.
+
+At a high level, it should return:
+
+- per-node legality or completion status
+- issues and blocking feedback
+- authoritative derived build state
+- builder-facing projections or summaries
+
+At terminal or explicitly requested points, evaluation may also return a full user-data sheet projection. That still counts as downstream output; it does not make the sheet the engine’s source of truth.
 
 ## Compiled Runtime Bundle
 
-Bundle statements are intentionally small:
+The compiled runtime bundle remains static and character-agnostic.
 
-```ts
-type BundleStatement =
-  | {
-      kind: "invoke";
-      capability: string;
-      op: string;
-      args: Record<string, unknown>;
-      when?: ConditionExpr;
-    }
-  | {
-      kind: "grant";
-      entity: string;
-      when?: ConditionExpr;
-    }
-  | {
-      kind: "constraint";
-      capability: string;
-      op: string;
-      args: Record<string, unknown>;
-      requiresFacts?: string[];
-      requiresInputs?: string[];
-      requiresResources?: string[];
-      requiresEntities?: string[];
-      when?: ConditionExpr;
-    };
-```
+It may contain:
 
-The bundle must not contain:
+- compiled rule fragments
+- selection or flow schema references
+- capability-owned runtime data
+- constraints, grants, and other execution metadata
 
-- request-side changes
-- acquire changes
-- direct user inputs
-- character-private runtime state
+It must not contain:
 
-## RuntimeRequest
+- request-side user state
+- frontend-local interaction state
+- per-character mutable build drafts
 
-`RuntimeRequest` is the dynamic change-request envelope:
+## Execution And Derived Output
 
-```ts
-type RuntimeRequest = {
-  changes: RuntimeChange[];
-};
-```
+The engine is responsible for more than legality checks.
 
-`RuntimeChange` is a discriminated union over:
+Evaluation should recompute the current authoritative build result from the submitted source state, including:
 
-- selection changes
-- raw input changes
-- acquire changes
+- derived build data
+- progression legality
+- node-level status
+- downstream projections needed by the builder or final review surfaces
 
-### Namespace rules
+This keeps the builder honest: the frontend displays engine-returned truth instead of reconstructing the character on its own.
 
-Request-side identifiers:
+## Projection
 
-- `sel:*` for selection schema IDs
-- `input:*` for request inputs
-- acquire change records in `RuntimeChange`
+Projection remains downstream of evaluation, not source truth.
 
-Runtime-state and published-surface identifiers:
+That means:
 
-- `entity:*`
-- `resource:*`
-- `private:*`
-- `constraint:*`
-- `fact:*`
+- builder summaries are projections
+- terminal full-sheet outputs are projections
+- review data is projection
+- explanation and provenance surfaces are projection
 
-`RuntimeRequest` must not inject `fact:*` directly. Inputs are normalized before facts are published.
+Projection is still important, but it should not become a back door for hiding engine state or frontend-owned logic inside the contract.
 
-## Dependency Semantics
+## Backend / Frontend Separation
 
-`dependsOn` remains reserved for static implementation dependencies, such as deferred mechanics waiting on missing capability support.
+The target deployment model is a real backend/frontend separation, but the refactor is intentionally contract-first.
 
-Runtime prerequisites use dedicated fields instead:
+Current stance:
 
-- `requiresFacts`
-- `requiresInputs`
-- `requiresResources`
-- `requiresEntities`
+- define the engine contract first
+- keep frontend and engine boundaries clean now
+- add API transport before or during implementation of the separated system
+- keep server-owned persistence or draft sessions out of MVP unless explicitly needed later
 
-This avoids overloading one field name with incompatible meanings.
+## Open Items
 
-## Typed Capability Registry
+The following details are still intentionally open:
 
-Runtime instructions are validated through a typed registry. The registry has two first-class instruction families:
+- the final transport/API shape
+- the exact normalized request type names
+- the exact schema of builder summaries and terminal full-sheet payloads
+- richer cleanup semantics such as active / blocked / orphaned projection surfaces
+- long-lived backend persistence
 
-```ts
-type InvokeSpec = {
-  kind: "invoke";
-  capability: string;
-  op: string;
-  version: string;
-  argsSchema: JsonSchema;
-  phase: RuntimeInvokePhase;
-  consumes: StateKey[];
-  produces: StateKey[];
-  publishes?: FactId[];
-  idempotent: boolean;
-  mayActivateEntities?: boolean;
-  mayMutateResources?: boolean;
-};
-
-type ConstraintSpec = {
-  kind: "constraint";
-  capability: string;
-  op: string;
-  version: string;
-  argsSchema: JsonSchema;
-  watches: StateKey[];
-  requiresFacts?: FactId[];
-  requiresInputs?: InputId[];
-  requiresResources?: ResourceId[];
-  requiresEntities?: EntityId[];
-  evaluationPhase: "constraints";
-  deferredWhenMissing: boolean;
-};
-```
-
-`InvokeSpec` declares change-consumption and change-production surfaces, not generic snapshot reads/writes. `ConstraintSpec` is first-class, but it is not a generic state-mutating invoke entry.
-
-## Shared Condition DSL
-
-`when` uses a shared condition DSL with typed operands. The engine does not provide a bare `level` primitive.
-
-Approved operand families:
-
-- constants
-- selection-derived metrics
-- published facts
-- resource amounts
-- boolean composition
-- numeric comparison
-
-If a ruleset needs a concept such as "paladin level", it must expose it as a typed metric or a published fact.
-
-## Runtime State Layers
-
-Runtime state is split into:
-
-- raw request inputs
-- owned entities
-- resources
-- capability-owned private state
-- published facts
-- constraint results
-
-Published facts are a narrow public interface for cross-capability reads. Internal caches, temporary calculations, and UI-only fields are not published facts.
-
-## Execution Model
-
-Execution is a deterministic global fixed-point over held changes:
-
-1. Activation
-2. Invoke execution
-3. Acquire resolution
-
-These three phases repeat as a super-cycle until there are no new observable changes across owned entities, published facts, resources, and unresolved acquire outcomes.
-
-This means the runtime is:
-
-- change-driven at the boundary
-- propagation-oriented in the core
-- convergence-bound by contract
-
-It is not:
-
-- a flow runner
-- a one-pass phase script
-- a pure snapshot calculator
-
-Only after convergence does the engine run:
-
-4. Constraint evaluation
-5. Projection
-
-Projection is intentionally open-ended. The runtime contract should expose projection fragments such as:
-
-```ts
-type RuntimeProjectionResult = {
-  projections: Array<{
-    projectionId: string;
-    schemaId: string;
-    data: Record<string, unknown>;
-  }>;
-};
-```
-
-This keeps runtime outputs extensible for rulesets and expansion packs. The engine must not imply one closed final result schema at this architecture layer, and new output semantics should not have to leak back into UI adapters just to exist.
-
-Execution order must be stable by:
-
-1. phase
-2. capability
-3. source entity order
-4. local statement order
-
-The runtime must also define:
-
-- idempotence requirements
-- maximum iteration count
-- cycle detection
-- non-convergence failure behavior
-
-## Imported State Rule
-
-Imported state is treated as raw input that still needs interpretation.
-
-It may enter only through `RuntimeRequest` and must pass through:
-
-- engine entry normalization
-- or a capability-owned adapter
-
-Imported data must not directly hydrate runtime internals unless a capability explicitly exposes a registry-validated import operation.
-
-## Issue Map
-
-This contract sits in the approved issue chain:
-
-- `#232`: `RuntimeRequest` adapter boundary
-- `#233`: architecture approval
-- `#235`: compiler scaffold
-- `#236`: selection-schema compilation
-- `#122`: first native capability slice
+Those should be decided on the `engine-refactor` line, but they should not force readers back into old plan docs just to understand the current architecture.

--- a/docs/data/ENGINE_RUNTIME_ARCHITECTURE.md
+++ b/docs/data/ENGINE_RUNTIME_ARCHITECTURE.md
@@ -2,6 +2,8 @@
 
 This document defines the current runtime-contract direction on the `engine-refactor` integration branch. It supersedes branch-era plan text that lived only in `docs/plans/`.
 
+The most important architectural reset is sequencing: this contract now starts from product semantics, not from the old executor loop. The architecture must first define the rule-universe boundary, the committed build state, and the caller-facing guarantees before it freezes any instruction model, bundle protocol, or convergence strategy.
+
 ## Purpose
 
 The engine refactor is moving toward a backend-style domain service with a contract-first boundary:
@@ -11,21 +13,25 @@ The engine refactor is moving toward a backend-style domain service with a contr
 - the frontend owns rendering and interaction
 - API transport and deployment can be introduced later without changing the core contract
 
-## Canonical Runtime Boundary
+## Top-Level MVP Invariant
 
-The runtime boundary now separates five things:
+For MVP, the rule-universe lifecycle is intentionally simple:
 
-1. Authored source
-2. Normalized pack IR
-3. Compiled runtime bundle
-4. `RulesContext`
-5. per-build request snapshot
+- the user selects a `RulesContext`
+- the engine compiles or normalizes that rule universe
+- the engine resolves a fixed flow for that context
+- the user builds inside that context
+- if the `RulesContext` changes, the current build state is discarded and the flow restarts
 
-The engine should execute a compiled bundle against rule-universe input plus per-build user input. It should not execute raw authored entity fields, and it should not depend on frontend click history or transient UI state.
+This keeps MVP honest. Cross-ruleset preservation, orphan handling, and cleanup are later extensions, not hidden assumptions in the initial runtime contract.
 
-## RulesContext
+## Canonical Product Objects
 
-`RulesContext` is the rule-universe input. Typical examples include:
+The current top-level architecture is built around five objects:
+
+### `RulesContext`
+
+The rule-universe input. Typical examples include:
 
 - selected ruleset or edition
 - enabled packs or sources
@@ -34,38 +40,52 @@ The engine should execute a compiled bundle against rule-universe input plus per
 
 `RulesContext` must be chosen before the engine resolves flow.
 
-## Flow Resolution
+### `CompiledRulesContext`
 
-The current direction is to treat flow as engine-owned output derived from `RulesContext`.
+The normalized or compiled executable form of the selected rule universe.
 
-At the contract level:
+This is important architecturally, but whether it becomes a public API object, a cache key, or a purely internal implementation detail is still open.
 
-- the frontend selects a `RulesContext`
-- the engine resolves a flow descriptor for that context
-- that flow is fixed for the chosen `RulesContext` in MVP
-- flow nodes use opaque IDs defined by the resolved flow, not engine-reserved domain nouns
+### `FlowDescriptor`
 
-The frontend still owns presentation, layout, and component behavior, but it should not invent or reorder the authoritative flow on its own.
+The fixed builder flow derived from the chosen rules context.
 
-## Request Snapshot
+Flow nodes should use opaque IDs from the resolved flow. The engine should not hardcode domain-specific UI nouns as its stable public contract.
 
-After flow resolution, the frontend submits a durable request snapshot for evaluation.
+### `CommittedBuildState`
 
-Important boundary rules:
+The durable user-owned build state under one fixed rules context.
 
-- submit durable user state, not raw UI events
-- clicks, hover state, open panels, and stepper mechanics stay in the frontend
-- the request remains generic and should avoid hardcoded D&D-specific engine primitives
-- the request-side vocabulary may continue to use generic concepts such as:
-  - input
-  - selection
-  - acquire
+For MVP:
 
-Older branch-era docs may refer to the request half as `RuntimeRequest`. That historical naming is still useful, but it is no longer sufficient by itself to describe the whole runtime source model.
+- it contains committed user data only
+- temporary in-step edits stay in the frontend until commit
+- it may be expressed in generic terms such as input, selection, and acquire
+- it does not include derived engine state, projection output, or raw UI events
 
-## Two Main Contract Surfaces
+Older branch-era docs may refer to the dynamic input half as `RuntimeRequest`. That historical name is still useful context, but `RuntimeRequest = { changes[] }` is no longer treated as settled architecture truth.
 
-The current contract direction is best understood as two surfaces:
+### `EvaluationResult`
+
+The authoritative engine response for the current committed build state.
+
+It should cover legality, progression, explanation, and builder-facing outputs rather than acting as a thin legality-only answer.
+
+## MVP Lifecycle
+
+The intended product flow is:
+
+1. The user selects a `RulesContext`.
+2. The engine compiles or normalizes that rules context.
+3. The engine resolves a fixed `FlowDescriptor`.
+4. The frontend collects temporary step edits locally.
+5. When the user commits a step, the frontend submits the current `CommittedBuildState`.
+6. The engine evaluates that committed state and returns a new `EvaluationResult`.
+7. If the `RulesContext` changes, the current `CommittedBuildState` is dropped and the flow restarts.
+
+## Public Contract Surfaces
+
+The current contract direction is best understood as two public surfaces plus an internal compilation step:
 
 ### `resolveFlow(rulesContext)`
 
@@ -77,50 +97,71 @@ That descriptor should define:
 - ordering
 - the structure needed for the frontend to render and navigate the builder
 
-### `evaluate(rulesContext, requestSnapshot)`
+The engine may compile or cache the rules context internally first. That compile step is architecturally important but not yet locked as its own public API surface.
 
-Recomputes the current authoritative build result for the submitted source state.
+### `evaluate(rulesContext, committedBuildState)`
+
+Recomputes the current authoritative build result for the submitted committed state.
 
 At a high level, it should return:
 
-- per-node legality or completion status
-- issues and blocking feedback
+- per-node legality and completion status
+- issues, unresolved state, assumptions, and blocking feedback
 - authoritative derived build state
 - builder-facing projections or summaries
+- explanation and provenance surfaces
 
-At terminal or explicitly requested points, evaluation may also return a full user-data sheet projection. That still counts as downstream output; it does not make the sheet the engine’s source of truth.
+At the terminal step, evaluation should also be able to return the full user-data sheet projection. That still counts as downstream output; it does not make the sheet the engine's source of truth.
 
-## Compiled Runtime Bundle
+## Source-State Boundary Rules
 
-The compiled runtime bundle remains static and character-agnostic.
+The engine boundary should obey these rules:
 
-It may contain:
+- submit committed user state, not raw UI events
+- clicks, hover state, open panels, and stepper mechanics stay in the frontend
+- the frontend must not send derived stats or final projections back as source truth
+- the engine should evaluate authored or compiled rules data plus committed build state, not frontend-local drafts
+- the request-side vocabulary should stay generic rather than hardcoding product nouns into the core engine contract
 
-- compiled rule fragments
-- selection or flow schema references
-- capability-owned runtime data
-- constraints, grants, and other execution metadata
+## User-Visible Guarantees Come Before Executor Design
 
-It must not contain:
+The engine contract must be able to support the following caller-facing guarantees:
 
-- request-side user state
-- frontend-local interaction state
-- per-character mutable build drafts
+- authoritative node status for the current flow
+- validation, unresolved state, assumptions, and blocking feedback
+- explanation and provenance for why outcomes exist
+- stable builder-facing projections during the flow
+- terminal full user-data sheet output
 
-## Execution And Derived Output
+These guarantees are more important than the shape of the internal loop. The executor exists to deliver these outcomes, not the other way around.
 
-The engine is responsible for more than legality checks.
+## Internal Architecture Still Intentionally Open
 
-Evaluation should recompute the current authoritative build result from the submitted source state, including:
+The following internal decisions are not settled architecture truth yet:
 
-- derived build data
-- progression legality
-- node-level status
-- downstream projections needed by the builder or final review surfaces
+- whether evaluation uses a fixed-point executor
+- whether any surviving request object still looks like `changes[]`
+- whether capability behavior is modeled as `capability + op + args` or something more domain-shaped
+- the exact ownership, typing, and merge rules for cross-capability facts, resources, and entities
+- the final compiler IR and bundle statement model
 
-This keeps the builder honest: the frontend displays engine-returned truth instead of reconstructing the character on its own.
+Earlier branch work around these ideas remains valuable implementation context, but those internal shapes should now be treated as provisional candidates rather than as already-approved architecture.
 
-## Projection
+## Cross-Capability Ownership Is A Required Follow-On
+
+Cross-capability surfaces cannot remain "just namespaced IDs" forever.
+
+The redesign still needs explicit ownership rules for:
+
+- which capability owns which facts, resources, and entities
+- which other capabilities may read them
+- whether anything may be multi-writer
+- how merge and conflict rules work
+- which changes are observable versus private
+
+Until that is defined, execution order must not quietly become the true conflict-resolution model.
+
+## Projection Remains Downstream Output
 
 Projection remains downstream of evaluation, not source truth.
 
@@ -131,15 +172,15 @@ That means:
 - review data is projection
 - explanation and provenance surfaces are projection
 
-Projection is still important, but it should not become a back door for hiding engine state or frontend-owned logic inside the contract.
+Projection is still first-class from a product perspective because the engine owes stable, explainable output surfaces to its callers.
 
 ## Backend / Frontend Separation
 
-The target deployment model is a real backend/frontend separation, but the refactor is intentionally contract-first.
+The target deployment model is a real backend/frontend separation, but the refactor remains contract-first.
 
 Current stance:
 
-- define the engine contract first
+- define source state and caller-facing guarantees first
 - keep frontend and engine boundaries clean now
 - add API transport before or during implementation of the separated system
 - keep server-owned persistence or draft sessions out of MVP unless explicitly needed later
@@ -149,9 +190,11 @@ Current stance:
 The following details are still intentionally open:
 
 - the final transport/API shape
-- the exact normalized request type names
+- whether `CompiledRulesContext` becomes a public handle or remains internal
+- the exact normalized type names for committed build state and evaluation outputs
 - the exact schema of builder summaries and terminal full-sheet payloads
-- richer cleanup semantics such as active / blocked / orphaned projection surfaces
+- richer selection lifecycle semantics such as active, blocked, orphaned, cleanup reasons, and refunds
 - long-lived backend persistence
+- the final change algebra and executor model
 
 Those should be decided on the `engine-refactor` line, but they should not force readers back into old plan docs just to understand the current architecture.

--- a/docs/data/README.md
+++ b/docs/data/README.md
@@ -9,8 +9,10 @@ This section documents the JSON pack and schema contract used by the builder.
 - `EXPORT_SCHEMA.md`: export payload expectations.
 - `CHARACTER_SPEC_V1.md`: flow-independent engine input contract (`CharacterSpec`).
 - `COMPUTE_RESULT_V1.md`: versioned engine output contract for `compute(spec, rulepack)`.
-- `ENGINE_RUNTIME_ARCHITECTURE.md`: approved runtime bundle/request/registry contract for the engine redesign.
+- `ENGINE_RUNTIME_ARCHITECTURE.md`: current runtime, flow-resolution, and evaluation contract direction for the engine redesign.
 - `SRD_AUTHENTICITY_VALIDATION.md`: automatic authenticity strategy for official SRD datasets.
+
+For the current `engine-refactor` branch status and the canonical refactor doc map, see `docs/engineering/ENGINE_REFACTOR_STATUS.md`.
 
 ## Recent updates
 

--- a/docs/engineering/ENGINE_REFACTOR_STATUS.md
+++ b/docs/engineering/ENGINE_REFACTOR_STATUS.md
@@ -24,23 +24,35 @@ Historical reasoning and implementation notes remain in `docs/plans/`.
 
 - treat the engine as a backend-style domain service
 - keep the refactor contract-first; add API transport as the boundary stabilizes
+- start from source state and caller-facing guarantees before freezing executor internals
 - resolve flow after `RulesContext` selection
 - keep flow fixed for that `RulesContext` in MVP
+- reset the current build state when `RulesContext` changes in MVP
 - have evaluation return authoritative build feedback rather than legality-only answers
-- keep frontend rendering and interaction out of engine truth
+- keep frontend rendering, temporary edits, and interaction out of engine truth
+
+## Top-Down Reset Principles
+
+The branch is now being reframed around these rules:
+
+- define `RulesContext` and committed build state before defining runtime change envelopes
+- define engine obligations and stable output surfaces before approving executor details
+- treat `RuntimeRequest = { changes[] }` as historical branch context, not settled architecture truth
+- treat fixed-point execution as a candidate implementation strategy, not as the starting architectural invariant
+- keep selection lifecycle, cleanup semantics, and cross-capability ownership as explicit design problems rather than hiding them inside ordering rules
 
 ## Issue Spine
 
 This branch currently treats the redesign spine as:
 
-- `#232`: request/runtime boundary migration from legacy compute paths
+- `#232`: legacy request/runtime boundary migration work from the older line
 - `#233`: architecture approval history for the runtime redesign
 - `#235`: compiler scaffold
 - `#236`: selection-schema compilation
-- `#238`: runtime state and change semantics
+- `#238`: runtime state and change semantics that must be defined before executor freeze
 - `#240`: `RulesContext` and rule-universe semantics
 - `#239`: projection and output contract
-- `#241`: blocked/orphaned cleanup semantics
+- `#241`: blocked/orphaned cleanup semantics and later selection lifecycle work
 - `#122`: first native capability slice
 
 ## Working Rules
@@ -48,6 +60,7 @@ This branch currently treats the redesign spine as:
 - New implementation PRs for the redesign should target `engine-refactor`, not `main`, unless explicitly stated otherwise.
 - `docs/plans/` may still hold design and implementation history, but stable conclusions must be promoted out of `docs/plans/`.
 - Earlier PRs that materially belong to the redesign may be absorbed into this branch narrative when necessary, even if they were merged elsewhere before the branch strategy was clarified.
+- Internal executor, IR, and registry details should stay provisional until source state, ownership, and output guarantees are explicit.
 
 ## Historical Plan Index
 

--- a/docs/engineering/ENGINE_REFACTOR_STATUS.md
+++ b/docs/engineering/ENGINE_REFACTOR_STATUS.md
@@ -1,0 +1,62 @@
+# Engine Refactor Status
+
+This file tracks the current integration-branch narrative for the engine redesign.
+
+## Integration Branch
+
+- Integration branch: `engine-refactor`
+- Current base line: carried forward from the older refactor branch at commit `894556e` (`#237`)
+- Purpose: unify the frontend/backend split and the engine redesign on one long-lived branch instead of scattering the work across isolated plan docs and issue-only narratives
+
+`#237` and other earlier refactor work on the older line should be treated as carried-forward assets, not as the final architecture truth.
+
+## Canonical Docs
+
+Current architecture truth lives in:
+
+- `docs/architecture.md`
+- `docs/data/ENGINE_RUNTIME_ARCHITECTURE.md`
+- `docs/engineering/ENGINE_REFACTOR_STATUS.md`
+
+Historical reasoning and implementation notes remain in `docs/plans/`.
+
+## Current Direction
+
+- treat the engine as a backend-style domain service
+- keep the refactor contract-first; add API transport as the boundary stabilizes
+- resolve flow after `RulesContext` selection
+- keep flow fixed for that `RulesContext` in MVP
+- have evaluation return authoritative build feedback rather than legality-only answers
+- keep frontend rendering and interaction out of engine truth
+
+## Issue Spine
+
+This branch currently treats the redesign spine as:
+
+- `#232`: request/runtime boundary migration from legacy compute paths
+- `#233`: architecture approval history for the runtime redesign
+- `#235`: compiler scaffold
+- `#236`: selection-schema compilation
+- `#238`: runtime state and change semantics
+- `#240`: `RulesContext` and rule-universe semantics
+- `#239`: projection and output contract
+- `#241`: blocked/orphaned cleanup semantics
+- `#122`: first native capability slice
+
+## Working Rules
+
+- New implementation PRs for the redesign should target `engine-refactor`, not `main`, unless explicitly stated otherwise.
+- `docs/plans/` may still hold design and implementation history, but stable conclusions must be promoted out of `docs/plans/`.
+- Earlier PRs that materially belong to the redesign may be absorbed into this branch narrative when necessary, even if they were merged elsewhere before the branch strategy was clarified.
+
+## Historical Plan Index
+
+Readers looking for branch history can start with:
+
+- `docs/plans/2026-03-15-issue-232-compute-runtime-input-adapters.md`
+- `docs/plans/2026-03-15-pack-compiler-migration-architecture.md`
+- `docs/plans/2026-03-17-issue-233-engine-capability-architecture-design.md`
+- `docs/plans/2026-03-17-issue-233-engine-capability-architecture-implementation.md`
+- `docs/plans/2026-04-01-engine-refactor-doc-consolidation.md`
+
+Those files explain how the branch got here. They do not replace the canonical docs above.

--- a/docs/engineering/ENGINE_REFACTOR_STATUS.md
+++ b/docs/engineering/ENGINE_REFACTOR_STATUS.md
@@ -62,6 +62,10 @@ This branch currently treats the redesign spine as:
 - Earlier PRs that materially belong to the redesign may be absorbed into this branch narrative when necessary, even if they were merged elsewhere before the branch strategy was clarified.
 - Internal executor, IR, and registry details should stay provisional until source state, ownership, and output guarantees are explicit.
 
+## Required Follow-Up Issues
+
+- `RulesContext` edit semantics must be treated as a separate follow-up architecture issue. This branch currently documents the MVP reset behavior, but that is not the final semantic answer for rule-universe edits. The follow-up must define what recomputation means when ruleset, packs, optional rules, bans, or overrides change mid-build, and whether reset remains only a temporary frontend policy.
+
 ## Historical Plan Index
 
 Readers looking for branch history can start with:

--- a/docs/plans/2026-03-15-issue-232-compute-runtime-input-adapters.md
+++ b/docs/plans/2026-03-15-issue-232-compute-runtime-input-adapters.md
@@ -1,5 +1,7 @@
 # Issue 232 Compute-Runtime Input Adapters Implementation Plan
 
+> Historical note: this file records March 2026 implementation planning on the older refactor line. Current canonical architecture truth for the `engine-refactor` integration branch now lives in `docs/architecture.md`, `docs/data/ENGINE_RUNTIME_ARCHITECTURE.md`, and `docs/engineering/ENGINE_REFACTOR_STATUS.md`. Read this file as historical implementation context, not as the latest contract.
+
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
 **Goal:** Land the first honest child lane under `#205` by removing `CharacterState` materialization from the public `compute()` path while preserving the existing `ComputeResult` contract and legacy API compatibility.

--- a/docs/plans/2026-03-15-pack-compiler-migration-architecture.md
+++ b/docs/plans/2026-03-15-pack-compiler-migration-architecture.md
@@ -1,5 +1,7 @@
 # Pack Compiler Migration Architecture
 
+> Historical note: this file records the March 2026 compiler-migration framing on the older refactor line. Current canonical architecture truth for the `engine-refactor` integration branch now lives in `docs/architecture.md`, `docs/data/ENGINE_RUNTIME_ARCHITECTURE.md`, and `docs/engineering/ENGINE_REFACTOR_STATUS.md`. Read this file as historical rationale and migration context, not as the latest branch contract.
+
 Date: 2026-03-15
 
 ## Goal

--- a/docs/plans/2026-03-17-issue-233-engine-capability-architecture-design.md
+++ b/docs/plans/2026-03-17-issue-233-engine-capability-architecture-design.md
@@ -1,5 +1,7 @@
 # Issue 233 Engine Capability Architecture Design
 
+> Historical note: this file records the March 2026 branch-era architecture design that landed through `#237`. It remains useful historical context, but the current `engine-refactor` branch no longer treats `docs/plans/` as the canonical architecture source. For current truth, read `docs/architecture.md`, `docs/data/ENGINE_RUNTIME_ARCHITECTURE.md`, and `docs/engineering/ENGINE_REFACTOR_STATUS.md` first.
+
 **Date:** 2026-03-17
 **Issue:** #233
 **Parent:** #199

--- a/docs/plans/2026-03-17-issue-233-engine-capability-architecture-implementation.md
+++ b/docs/plans/2026-03-17-issue-233-engine-capability-architecture-implementation.md
@@ -1,5 +1,7 @@
 # Issue 233 Engine Capability Architecture Implementation Plan
 
+> Historical note: this file records the March 2026 implementation plan for codifying the then-current `#233` contract on the older refactor line. Current canonical architecture truth for the `engine-refactor` branch now lives outside `docs/plans/`, in `docs/architecture.md`, `docs/data/ENGINE_RUNTIME_ARCHITECTURE.md`, and `docs/engineering/ENGINE_REFACTOR_STATUS.md`.
+
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
 **Goal:** Codify the approved issue #233 engine architecture as schema-level contracts and documentation without widening current engine execution work beyond the existing `#232` boundary.

--- a/docs/plans/2026-04-01-engine-refactor-doc-consolidation.md
+++ b/docs/plans/2026-04-01-engine-refactor-doc-consolidation.md
@@ -1,0 +1,208 @@
+# Engine Refactor Doc Consolidation Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Consolidate the engine-refactor architecture truth onto the new `engine-refactor` line, move current conclusions out of `docs/plans/`, and update outdated contract wording before opening a review PR against `engine-refactor`.
+
+**Architecture:** Keep `docs/plans/` as historical process records and move current refactor truth into a small canonical set outside `docs/plans/`. Use `docs/architecture.md` for the system boundary, `docs/data/ENGINE_RUNTIME_ARCHITECTURE.md` for the current engine contract, and `docs/engineering/ENGINE_REFACTOR_STATUS.md` for the active branch spine, issue map, and migration status. Old plan docs should remain readable but explicitly marked as historical references rather than live architecture truth.
+
+**Tech Stack:** Markdown docs, Trellis task tracking, git branches/worktrees, GitHub PR workflow
+
+---
+
+### Task 1: Establish The Canonical Doc Set
+
+**Files:**
+- Modify: `docs/architecture.md`
+- Modify: `docs/data/README.md`
+- Create: `docs/engineering/ENGINE_REFACTOR_STATUS.md`
+
+**Step 1: Write the target outline**
+
+Lock the target doc roles before rewriting content:
+- `docs/architecture.md`
+  - system-level boundary
+  - frontend / backend / engine / rules data responsibilities
+  - note that `engine-refactor` is the integration line for the redesign
+- `docs/data/ENGINE_RUNTIME_ARCHITECTURE.md`
+  - current runtime contract only
+- `docs/engineering/ENGINE_REFACTOR_STATUS.md`
+  - issue spine
+  - branch strategy
+  - active lane
+  - historical-plan index
+- `docs/data/README.md`
+  - point readers to the canonical runtime and refactor docs
+
+**Step 2: Implement the minimal skeleton**
+
+Add the new status doc and update the existing top-level doc pointers so the canonical set exists before any historical notes are added.
+
+**Step 3: Verify the structure**
+
+Run:
+
+```bash
+rg -n "engine-refactor|ENGINE_REFACTOR_STATUS|ENGINE_RUNTIME_ARCHITECTURE" docs/architecture.md docs/data/README.md docs/engineering/ENGINE_REFACTOR_STATUS.md
+```
+
+Expected:
+- each canonical file is discoverable by name
+- the new status doc is referenced from stable docs
+
+### Task 2: Rewrite The Current Runtime Contract To Match The New Direction
+
+**Files:**
+- Modify: `docs/data/ENGINE_RUNTIME_ARCHITECTURE.md`
+- Modify: `docs/architecture.md`
+
+**Step 1: Remove the outdated branch-era stance**
+
+Replace or rewrite statements that are no longer current on the new refactor line, especially:
+- `CompiledRuntimeBundle + RuntimeRequest` as the whole engine source model
+- request-centered `changes[]` as the only top-level source contract
+- flow as merely projection-only output without a fixed flow-resolution role
+- wording that does not leave room for backend/frontend separation
+
+**Step 2: Write the current contract**
+
+The updated runtime/architecture docs should reflect the currently agreed direction:
+- engine as backend-style domain service
+- contract-first separation, API later
+- rules data / compiled bundle / engine / frontend separation
+- `RulesContext` as the rule-universe input
+- flow resolved after rules selection
+- flow fixed for that `RulesContext`
+- evaluation returns authoritative build feedback, not just legality
+- projection remains downstream output, but product-facing builder outputs are still engine-returned
+
+Keep the wording high-level where details are still open. Do not invent final payload fields that have not been agreed.
+
+**Step 3: Verify key terms**
+
+Run:
+
+```bash
+rg -n "RulesContext|resolveFlow|evaluate|backend|fixed flow|engine-refactor" docs/architecture.md docs/data/ENGINE_RUNTIME_ARCHITECTURE.md
+```
+
+Expected:
+- old `RuntimeRequest`-only framing is gone
+- the new boundary terms appear in the canonical docs
+
+### Task 3: Downgrade Historical Plan Docs Out Of Source-Of-Truth Status
+
+**Files:**
+- Modify: `docs/plans/2026-03-15-issue-232-compute-runtime-input-adapters.md`
+- Modify: `docs/plans/2026-03-15-pack-compiler-migration-architecture.md`
+- Modify: `docs/plans/2026-03-17-issue-233-engine-capability-architecture-design.md`
+- Modify: `docs/plans/2026-03-17-issue-233-engine-capability-architecture-implementation.md`
+
+**Step 1: Add historical-context notes**
+
+At the top of each plan doc, add a short note that says:
+- this file records historical planning/design state on the older refactor line
+- current canonical architecture truth lives outside `docs/plans/`
+- point readers to:
+  - `docs/architecture.md`
+  - `docs/data/ENGINE_RUNTIME_ARCHITECTURE.md`
+  - `docs/engineering/ENGINE_REFACTOR_STATUS.md`
+
+**Step 2: Correct only the most misleading outdated claims**
+
+Do not rewrite every historical paragraph. Only fix or annotate statements that would materially mislead a current reader, especially where the old text now conflicts with:
+- `RulesContext` as first-class source state
+- the new `engine-refactor` integration-branch narrative
+- the separation between historical plan docs and current truth
+
+**Step 3: Verify the downgrade markers**
+
+Run:
+
+```bash
+rg -n "historical|canonical|ENGINE_REFACTOR_STATUS|ENGINE_RUNTIME_ARCHITECTURE" docs/plans/2026-03-15-issue-232-compute-runtime-input-adapters.md docs/plans/2026-03-15-pack-compiler-migration-architecture.md docs/plans/2026-03-17-issue-233-engine-capability-architecture-design.md docs/plans/2026-03-17-issue-233-engine-capability-architecture-implementation.md
+```
+
+Expected:
+- all four plan docs clearly point to the canonical docs
+
+### Task 4: Record The New Integration-Branch Narrative
+
+**Files:**
+- Modify: `docs/engineering/ENGINE_REFACTOR_STATUS.md`
+- Optional modify: `docs/data/README.md`
+
+**Step 1: Define the new branch narrative**
+
+Record that:
+- `engine-refactor` is the new integration branch for the overall refactor
+- PR `#237` is treated as a carried-forward asset on this line, not the final word
+- already-merged or previously-landed refactor-related work may be absorbed into this line when necessary
+- future doc and implementation work should organize around this branch instead of scattered issue-plan docs
+
+**Step 2: Record the issue spine**
+
+List the current issue chain and responsibilities at a high level:
+- `#232`
+- `#233`
+- `#235`
+- `#236`
+- `#238`
+- `#239`
+- `#240`
+- `#241`
+- `#122`
+
+Keep it concise. This is a branch-status doc, not another ADR.
+
+**Step 3: Verify discoverability**
+
+Run:
+
+```bash
+rg -n "894556e|#237|engine-refactor|#232|#233|#239|#241" docs/engineering/ENGINE_REFACTOR_STATUS.md
+```
+
+Expected:
+- the branch narrative and issue spine are explicit
+
+### Task 5: Final Review And PR Preparation
+
+**Files:**
+- No new files expected beyond the docs above
+
+**Step 1: Review the diff**
+
+Run:
+
+```bash
+git diff --stat
+git diff -- docs/architecture.md docs/data/README.md docs/data/ENGINE_RUNTIME_ARCHITECTURE.md docs/engineering/ENGINE_REFACTOR_STATUS.md docs/plans/2026-03-15-issue-232-compute-runtime-input-adapters.md docs/plans/2026-03-15-pack-compiler-migration-architecture.md docs/plans/2026-03-17-issue-233-engine-capability-architecture-design.md docs/plans/2026-03-17-issue-233-engine-capability-architecture-implementation.md docs/plans/2026-04-01-engine-refactor-doc-consolidation.md
+```
+
+Expected:
+- the PR is doc-focused
+- no opportunistic engine/runtime code changes are mixed in
+
+**Step 2: Run minimal validation**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected:
+- no whitespace or patch-format issues
+
+**Step 3: Prepare PR summary**
+
+The PR summary should state:
+- `engine-refactor` is now the integration branch for the redesign
+- current architecture truth has been consolidated outside `docs/plans/`
+- outdated branch-era contract wording was corrected
+- historical plan docs remain available but no longer act as live architecture truth
+
+**Step 4: Human commit / push / PR**
+
+Per repo workflow, leave a clean reviewable diff for commit/push/PR creation on this branch rather than committing inside the task.


### PR DESCRIPTION
## Summary
- consolidate current engine-refactor architecture truth into the canonical docs outside `docs/plans/`
- reframe the runtime contract top-down around `RulesContext`, committed build state, flow resolution, and caller-facing engine obligations
- demote older executor-first assumptions such as `RuntimeRequest = { changes[] }`, fixed-point execution, and generic op dispatch from approved architecture truth to provisional internal candidates

## Why
- the previous refactor narrative still started too low in the stack, from executor mechanics instead of the product's hardest invariant
- for MVP, the current docs describe reset behavior when `RulesContext` changes, but the deeper `RulesContext` edit semantics are still a separate follow-up architecture issue
- the engine contract should first define source state, lifecycle, and explainable output guarantees before freezing IR, registry, or convergence details

## Notes
- docs-only change; no engine/runtime implementation changes are included
- base branch `engine-refactor` is carried forward from commit `894556e` (`#237`)
- `.trellis/tasks/...` was intentionally left out of this PR
- `RulesContext` edit semantics are explicitly listed as a required follow-up issue in the branch status doc and are not claimed as resolved here

## Verification
- `git diff --cached --check` before the initial commit
- `git diff --check` after the top-down rewrite and follow-up issue note
- targeted `rg` checks against canonical doc terms such as `RulesContext`, `CommittedBuildState`, `RuntimeRequest`, and `fixed-point`
